### PR TITLE
Match OpenEXR attribute names when semantically equivalent (#105)

### DIFF
--- a/src/main/python/camdkit/bmd/reader.py
+++ b/src/main/python/camdkit/bmd/reader.py
@@ -114,7 +114,7 @@ def to_clip(metadata_file: typing.IO) -> camdkit.model.Clip:
   # focus_position
   clip.focus_position = tuple(int(m["distance"][:-2]) for m in frame_data)
 
-  # entrance_pupil_position not supported
+  # entrance_pupil_offset not supported
 
   # t_number
   clip.t_number = tuple(round(float(m["aperture"][1:]) * 1000) for m in frame_data)

--- a/src/main/python/camdkit/canon/reader.py
+++ b/src/main/python/camdkit/canon/reader.py
@@ -66,7 +66,7 @@ def to_clip(static_csv: typing.IO, frames_csv: typing.IO) -> camdkit.model.Clip:
   # focus_position
   clip.lens_focus_position = tuple(round(_read_float32_as_hex(m["FocusPosition"]) * 1000) for m in frame_data)
 
-  # entrance_pupil_position not supported
+  # entrance_pupil_offset not supported
 
   # t_number
   if int(first_frame_data['ApertureMode']) == 2:

--- a/src/main/python/camdkit/examples.py
+++ b/src/main/python/camdkit/examples.py
@@ -11,7 +11,7 @@ from camdkit.model import Clip, PROTOCOL_STRING, VERSION_STRING
 
 def get_recommended_static_example():
   clip = _get_recommended_dynamic_clip()
-  clip.camera_id = "A"
+  clip.camera_label = "A"
   clip.lens_make = "LensMaker"
   clip.lens_model = "Model15"
   clip.active_sensor_physical_dimensions = Dimensions(width=36000,height=24000)
@@ -19,7 +19,7 @@ def get_recommended_static_example():
 
 def get_complete_static_example():
   clip = _get_complete_dynamic_clip()
-  clip.camera_id = "A"
+  clip.camera_label = "A"
   clip.lens_make = "LensMaker"
   clip.lens_model = "Model15"
   clip.lens_nominal_focal_length = 14
@@ -70,7 +70,7 @@ def _get_recommended_dynamic_clip():
   clip.lens_f_number = (4000,)
   clip.lens_focal_length = (24.305,)
   clip.lens_focus_distance = (1000,)
-  clip.lens_entrance_pupil_distance = (Fraction(1000,100),)
+  clip.lens_entrance_pupil_offset = (Fraction(1000,100),)
   clip.lens_encoders = (FizEncoders(focus=0.1, iris=0.2, zoom=0.3),)
   clip.lens_distortion = (Distortion([1.0,2.0,3.0], [1.0,2.0]),)
   clip.lens_perspective_shift = (PerspectiveShift(0.1, 0.2),)
@@ -119,7 +119,7 @@ def _get_complete_dynamic_clip():
   clip.lens_t_number = (4100,)
   clip.lens_focal_length = (24.305,)
   clip.lens_focus_distance = (1000,)
-  clip.lens_entrance_pupil_distance = (Fraction(1000,100),)
+  clip.lens_entrance_pupil_offset = (Fraction(1000,100),)
   clip.lens_encoders = (FizEncoders(focus=0.1, iris=0.2, zoom=0.3),)
   clip.lens_distortion_overscan = (1.0,)
   clip.lens_distortion_scale = (1.0,)

--- a/src/main/python/camdkit/model.py
+++ b/src/main/python/camdkit/model.py
@@ -121,10 +121,10 @@ class CameraFirmware(StringParameter):
   units = None
   section = "camera"
   
-class CameraId(StringParameter):
+class CameraLabel(StringParameter):
   """Free string that identifies the camera - e.g. 'A'"""
   
-  canonical_name = "id"
+  canonical_name = "label"
   sampling = Sampling.STATIC
   units = None
   section = "camera"
@@ -937,12 +937,12 @@ class FocusDistance(StrictlyPositiveIntegerParameter):
   units = "millimeter"
   section = "lens"
 
-class EntrancePupilDistance(RationalParameter):
-  """Position of the entrance pupil relative to the nominal imaging plane
+class EntrancePupilOffset(RationalParameter):
+  """Offset of the entrance pupil relative to the nominal imaging plane
   (positive if the entrance pupil is located on the side of the nominal imaging
   plane that is towards the object, and negative otherwise)"""
 
-  canonical_name = "entrancePupilDistance"
+  canonical_name = "entrancePupilOffset"
   sampling = Sampling.REGULAR
   units = "millimeter"
   section = "lens"
@@ -1204,7 +1204,7 @@ class Clip(ParameterContainer):
   camera_model: typing.Optional[str] = CameraModel()
   camera_firmware: typing.Optional[str] = CameraFirmware()
   camera_serial_number: typing.Optional[str] = CameraSerialNumber()
-  camera_id: typing.Optional[str] = CameraId()
+  camera_label: typing.Optional[str] = CameraLabel()
   capture_fps: typing.Optional[numbers.Rational] = CaptureFPS()
   device_make: typing.Optional[str] = DeviceMake()
   device_model: typing.Optional[str] = DeviceModel()
@@ -1231,7 +1231,7 @@ class Clip(ParameterContainer):
   lens_distortion_scale: typing.Optional[typing.Tuple[Orientations]] = DistortionScale()
   lens_distortion_shift: typing.Optional[typing.Tuple[DistortionShift]] = LensDistortionShift()
   lens_encoders: typing.Optional[typing.Tuple[LensEncoders]] = LensEncoders()
-  lens_entrance_pupil_distance: typing.Optional[typing.Tuple[numbers.Rational]] = EntrancePupilDistance()
+  lens_entrance_pupil_offset: typing.Optional[typing.Tuple[numbers.Rational]] = EntrancePupilOffset()
   lens_exposure_falloff: typing.Optional[typing.Tuple[Orientations]] = LensExposureFalloff()
   lens_f_number: typing.Optional[typing.Tuple[numbers.Integral]] = FStop()
   lens_focal_length: typing.Optional[typing.Tuple[numbers.Real]] = FocalLength()

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -83,7 +83,7 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
 
   cooke_metadata = tuple(cooke.lens_data_from_binary_string(bytes(int(i, 16) for i in m["Cooke Metadata"].split("/"))) for m in csv_data)
 
-  clip.entrance_pupil_position = tuple(m.entrance_pupil_position for m in cooke_metadata)
+  clip.entrance_pupil_offset = tuple(m.entrance_pupil_position for m in cooke_metadata)
 
   clip.t_number = tuple(m.aperture_value * 10 for m in cooke_metadata)
 

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -194,7 +194,7 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
 
   clip.focus_position = tuple(round(float(m["Focus Distance (ft)"]) * 12 * 25.4) for m in csv_data)
 
-  # TODO: clip.entrance_pupil_position
+  # TODO: clip.entrance_pupil_offset
 
   clip.t_number = tuple(round(t_number_from_frac_stop(m["Aperture"]) * 1000) for m in csv_data)
 

--- a/src/test/python/test_canon_reader.py
+++ b/src/test/python/test_canon_reader.py
@@ -27,7 +27,7 @@ class CanonReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.shutter_angle, 180000)    # shutter_angle: 180 deg
 
-    self.assertIsNone(clip.lens_entrance_pupil_distance)
+    self.assertIsNone(clip.lens_entrance_pupil_offset)
 
     self.assertEqual(clip.lens_t_number[0], 4500)        # t_number: 4.5
 

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -37,7 +37,7 @@ class ModelTest(unittest.TestCase):
     clip.camera_model = "Hello"
     clip.camera_serial_number = "132456"
     clip.camera_firmware = "7.1"
-    clip.camera_id = "A"
+    clip.camera_label = "A"
     clip.device_make = "ABCD"
     clip.device_model = "EFGH"
     clip.device_firmware = "1.0.1a"
@@ -98,7 +98,7 @@ class ModelTest(unittest.TestCase):
     clip.lens_f_number = (1200, 2800)
     clip.lens_focal_length = (2.0, 4.0)
     clip.lens_focus_distance = (2, 4)
-    clip.lens_entrance_pupil_distance = (Fraction(1, 2), Fraction(13, 7))
+    clip.lens_entrance_pupil_offset = (Fraction(1, 2), Fraction(13, 7))
     clip.lens_encoders = (FizEncoders(focus=0.1, iris=0.2, zoom=0.3),
                           FizEncoders(focus=0.1, iris=0.2, zoom=0.3))
     clip.lens_raw_encoders = (RawFizEncoders(focus=1, iris=2, zoom=3),
@@ -126,7 +126,7 @@ class ModelTest(unittest.TestCase):
     self.assertEqual(d["static"]["camera"]["model"], "Hello")
     self.assertEqual(d["static"]["camera"]["serialNumber"], "132456")
     self.assertEqual(d["static"]["camera"]["firmwareVersion"], "7.1")
-    self.assertEqual(d["static"]["camera"]["id"], "A")
+    self.assertEqual(d["static"]["camera"]["label"], "A")
     self.assertEqual(d["static"]["lens"]["make"], "ABC")
     self.assertEqual(d["static"]["lens"]["model"], "FGH")
     self.assertEqual(d["static"]["lens"]["serialNumber"], "123456789")
@@ -180,7 +180,7 @@ class ModelTest(unittest.TestCase):
     self.assertTupleEqual(d["lens"]["fStop"], (1200, 2800))
     self.assertTupleEqual(d["lens"]["focalLength"], (2.0, 4.0))
     self.assertTupleEqual(d["lens"]["focusDistance"], (2, 4))
-    self.assertTupleEqual(d["lens"]["entrancePupilDistance"], ({ "num":1, "denom":2 }, { "num":13, "denom":7 }))
+    self.assertTupleEqual(d["lens"]["entrancePupilOffset"], ({ "num":1, "denom":2 }, { "num":13, "denom":7 }))
     self.assertTupleEqual(d["lens"]["encoders"], ({ "focus":0.1, "iris":0.2, "zoom":0.3 },
                                                   { "focus":0.1, "iris":0.2, "zoom":0.3 }))
     self.assertTupleEqual(d["lens"]["rawEncoders"], ({ "focus":1, "iris":2, "zoom":3 },
@@ -374,19 +374,19 @@ class ModelTest(unittest.TestCase):
 
     self.assertTupleEqual(clip.lens_focus_distance, value)
 
-  def test_entrance_pupil_distance(self):
+  def test_entrance_pupil_offset(self):
     clip = Clip()
 
-    self.assertIsNone(clip.lens_entrance_pupil_distance)
+    self.assertIsNone(clip.lens_entrance_pupil_offset)
 
     with self.assertRaises(ValueError):
-      clip.lens_entrance_pupil_distance = 0.6
+      clip.lens_entrance_pupil_offset = 0.6
 
     value = (Fraction(5,7), 7)
 
-    clip.lens_entrance_pupil_distance = value
+    clip.lens_entrance_pupil_offset = value
 
-    self.assertTupleEqual(clip.lens_entrance_pupil_distance, value)
+    self.assertTupleEqual(clip.lens_entrance_pupil_offset, value)
 
   def test_fdl_link(self):
     clip = Clip()

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -40,7 +40,7 @@ class REDReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.focus_position[0], 410)
 
-    self.assertEqual(clip.entrance_pupil_position[0], 127)
+    self.assertEqual(clip.entrance_pupil_offset[0], 127)
 
     self.assertEqual(clip.t_number[0], 5600)
 


### PR DESCRIPTION
Harmonize camdkit's cameraId with OpenEXR / ACES's cameraLabel; similarly for entrancePupilPosition -> entrancePupilOffset.