### PR TITLE
Rename focal_length to pinhole_focal_length, adjust users

### DIFF
--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -79,7 +79,10 @@ def to_clip(csv_path: str) -> camdkit.model.Clip:
         height=pix_dims.height * pixel_pitch / 1000.0
       )
 
-    clip.lens_focal_length = tuple(float(m["Lens Focal Length"]) for m in csv_data)
+    focal_lengths = set([m["Lens Focal Length"] for m in csv_data])
+    if len(focal_lengths) == 1:
+      focal_length = float(focal_lengths.pop())
+      clip.lens_nominal_focal_length = focal_length
 
     clip.lens_focus_distance = tuple(float(m["Lens Focus Distance"]) for m in csv_data)
 

--- a/src/main/python/camdkit/bmd/reader.py
+++ b/src/main/python/camdkit/bmd/reader.py
@@ -109,7 +109,10 @@ def to_clip(metadata_file: typing.IO) -> camdkit.model.Clip:
   # sampled metadata
 
   # focal_length
-  clip.lens_focal_length = tuple(float(m["focal_length"][:-2]) for m in frame_data)
+    focal_lengths = set([m["focal_length"][:-2] for m in frame_data])
+    if len(focal_lengths) == 1:
+      focal_length = float(focal_lengths.pop())
+      clip.lens_nominal_focal_length = focal_length
 
   # focus_position
   clip.lens_focus_distance = tuple(float(m["distance"][:-2]) for m in frame_data)

--- a/src/main/python/camdkit/canon/reader.py
+++ b/src/main/python/camdkit/canon/reader.py
@@ -61,7 +61,10 @@ def to_clip(static_csv: typing.IO, frames_csv: typing.IO) -> camdkit.model.Clip:
   # sampled metadata
 
   # focal_length
-  clip.lens_focal_length = tuple(Fraction(m["FocalLength"]) for m in frame_data)
+  focal_lengths = set(Fraction(m["FocalLength"]) for m in frame_data)
+  if len(focal_lengths) == 1:
+    focal_length = float(focal_lengths.pop())
+    clip.lens_nominal_focal_length = focal_length
 
   # focus_position
   clip.lens_focus_distance = tuple(_read_float32_as_hex(m["FocusPosition"]) for m in frame_data)

--- a/src/main/python/camdkit/examples.py
+++ b/src/main/python/camdkit/examples.py
@@ -26,7 +26,7 @@ def _unwrap_clip_to_pseudo_frame(wrapped_clip: JsonSchemaValue) -> JsonSchemaVal
     ("lens", "entrancePupilOffset"),
     ("lens", "exposureFalloff"),
     ("lens", "fStop"),
-    ("lens", "focalLength"),
+    ("lens", "pinholeFocalLength"),
     ("lens", "focusDistance"),
     ("lens", "projectionOffset"),
     ("lens", "rawEncoders"),
@@ -160,7 +160,7 @@ def _get_recommended_dynamic_clip():
   clip.transforms = ((Transform(translation=v, rotation=r, id="Camera"),),)
   # lens
   clip.lens_f_number = (4.0,)
-  clip.lens_focal_length = (24.305,)
+  clip.lens_pinhole_focal_length = (24.305,)
   clip.lens_focus_distance = (10.0,)
   clip.lens_entrance_pupil_offset = (0.123,)
   clip.lens_encoders = (FizEncoders(focus=0.1, iris=0.2, zoom=0.3),)

--- a/src/main/python/camdkit/lens_types.py
+++ b/src/main/python/camdkit/lens_types.py
@@ -262,13 +262,12 @@ The parameter shall contain at least one normalised values (0..1) for the FIZ en
     by the diameter of the entrance pupil.
     """
 
-    # TODO: file issue to get this renamed to lens_pinhole_focal_length in the clip and pinholeFocalLength in the JSON
-    focal_length: Annotated[tuple[NonNegativeFloat, ...] | None,
-      Field(alias="focalLength",
+    pinhole_focal_length: Annotated[tuple[NonNegativeFloat, ...] | None,
+      Field(alias="pinholeFocalLength",
             json_schema_extra={"units": MILLIMETER,
-                               "clip_property": "lens_focal_length",
+                               "clip_property": "lens_pinhole_focal_length",
                                "constraints": NON_NEGATIVE_REAL})] = None
-    """Focal length of the lens."""
+    """Distance between the pinhole and the image plane in the simple CGI pinhole camera model."""
 
     focus_distance: Annotated[tuple[StrictlyPositiveFloat, ...] | None,
       Field(alias="focusDistance",

--- a/src/main/python/camdkit/mosys/f4.py
+++ b/src/main/python/camdkit/mosys/f4.py
@@ -280,7 +280,7 @@ class F4PacketParser:
       # Assuming a full frame 35mm active sensor 36x24mm
       # f = 36/[2*tand(FoV/2)]
       fov_radians = fov_h * math.pi / 180.0
-      frame.lens_focal_length = (36.0 / (2.0 * math.tan(fov_radians/2.0)),)
+      frame.lens_pinhole_focal_length = (36.0 / (2.0 * math.tan(fov_radians/2.0)),)
       frame.lens_encoders = (FizEncoders(focus, iris, zoom),)
       frame.lens_distortions = ((Distortion([k1, k2],),),)
       frame.lens_projection_offset = (ProjectionOffset(cx, cy),)

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -77,7 +77,10 @@ def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Cli
 
   clip.shutter_angle = float(clip_metadata["Shutter (deg)"])
 
-  clip.lens_focal_length = tuple(int(m["Focal Length"]) for m in csv_data)
+  focal_lengths = set([float(m["Focal Length"]) for m in csv_data])
+  if len(focal_lengths) == 1:
+    focal_length = float(focal_lengths.pop())
+    clip.lens_nominal_focal_length = focal_length
 
   clip.lens_focus_distance = tuple(int(m["Focus Distance"]) for m in csv_data)
 

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -190,7 +190,10 @@ def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Cl
 
   clip.duration = len(csv_data)/clip_fps
 
-  clip.lens_focal_length = tuple(float(m["Focal Length (mm)"]) for m in csv_data)
+  focal_lengths = set([float(m["Focal Length (mm)"]) for m in csv_data])
+  if len(focal_lengths) == 1:
+    focal_length = float(focal_lengths.pop())
+    clip.lens_nominal_focal_length = focal_length
 
   clip.lens_focus_distance = tuple(float(m["Focus Distance (ft)"]) * 12.0 * 25.4 / 1000.0 for m in csv_data)
 

--- a/src/test/python/test_arri_reader.py
+++ b/src/test/python/test_arri_reader.py
@@ -38,7 +38,7 @@ class ARRIReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.capture_frame_rate, 24)
 
-    self.assertEqual(clip.lens_focal_length[0], 40)
+    self.assertEqual(clip.lens_nominal_focal_length, 40)
 
     self.assertEqual(clip.lens_focus_distance[0], 4.812)
 

--- a/src/test/python/test_bmd_reader.py
+++ b/src/test/python/test_bmd_reader.py
@@ -39,7 +39,7 @@ class BMDReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.capture_frame_rate, 48)
 
-    self.assertEqual(clip.lens_focal_length[0], 50)
+    self.assertEqual(clip.lens_nominal_focal_length, 50)
 
     self.assertEqual(clip.lens_focus_distance[0], 991)
 

--- a/src/test/python/test_canon_reader.py
+++ b/src/test/python/test_canon_reader.py
@@ -21,7 +21,7 @@ class CanonReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.iso, 1600)                # ISO: 1600
 
-    self.assertEqual(clip.lens_focal_length[0], 18)      # focal_length: 18 mm
+    self.assertEqual(clip.lens_nominal_focal_length, 18)      # focal_length: 18 mm
 
     self.assertEqual(clip.lens_focus_distance[0], 0.5)   # focus_position: 0.5 mm
 

--- a/src/test/python/test_clip.py
+++ b/src/test/python/test_clip.py
@@ -204,7 +204,7 @@ class ClipTestCases(unittest.TestCase):
         # reference values
         lens_t_number = (2000, 4000)
         lens_f_number = (1200, 2800)
-        lens_focal_length = (2.0, 4.0)
+        lens_pinhole_focal_length = (2.0, 4.0)
         lens_focus_distance = (2, 4)
         lens_entrance_pupil_offset = (1.23, 2.34)
         lens_encoders = (FizEncoders(focus=0.1, iris=0.2, zoom=0.3),
@@ -236,9 +236,9 @@ class ClipTestCases(unittest.TestCase):
         self.assertIsNone(clip.lens_f_number)
         clip.lens_f_number = lens_f_number
         self.assertEqual(lens_f_number, clip.lens_f_number)
-        self.assertIsNone(clip.lens_focal_length)
-        clip.lens_focal_length = lens_focal_length
-        self.assertEqual(lens_focal_length, clip.lens_focal_length)
+        self.assertIsNone(clip.lens_pinhole_focal_length)
+        clip.lens_pinhole_focal_length = lens_pinhole_focal_length
+        self.assertEqual(lens_pinhole_focal_length, clip.lens_pinhole_focal_length)
         self.assertIsNone(clip.lens_focus_distance)
         clip.lens_focus_distance = lens_focus_distance
         self.assertEqual(lens_focus_distance, clip.lens_focus_distance)
@@ -277,7 +277,7 @@ class ClipTestCases(unittest.TestCase):
         # self.assertTupleEqual(clip_as_json["lens"]["custom"], lens_custom)
         self.assertTupleEqual(clip_as_json["lens"]["tStop"], lens_t_number)
         self.assertTupleEqual(clip_as_json["lens"]["fStop"], lens_f_number)
-        self.assertTupleEqual(clip_as_json["lens"]["focalLength"], lens_focal_length)
+        self.assertTupleEqual(clip_as_json["lens"]["pinholeFocalLength"], lens_pinhole_focal_length)
         self.assertTupleEqual(clip_as_json["lens"]["focusDistance"], lens_focus_distance)
         self.assertTupleEqual(clip_as_json["lens"]["entrancePupilOffset"], lens_entrance_pupil_offset)
         self.assertTupleEqual(clip_as_json["lens"]["encoders"], ({ "focus":0.1, "iris":0.2, "zoom":0.3 },

--- a/src/test/python/test_lens_types.py
+++ b/src/test/python/test_lens_types.py
@@ -92,6 +92,10 @@ class LensTypesTestCases(unittest.TestCase):
     def test_regular_lens_schemas_match(self):
         expected: JsonSchemaValue = CLASSIC_LENS_SCHEMA
         actual = Lens.make_json_schema()
+        with open("/tmp/sorted_expected_lens_schema.json", "w") as ef:
+            json.dump(expected, ef, indent=4, sort_keys=True)
+        with open("/tmp/sorted_actual_lens_schema.json", "w") as cf:
+            json.dump(actual, cf, indent=4, sort_keys=True)
         self.assertEqual(expected, actual)
 
 

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -114,7 +114,7 @@ class ModelTest(unittest.TestCase):
 
     clip.lens_t_number = (2000, 4000)
     clip.lens_f_number = (1200, 2800)
-    clip.lens_focal_length = (2.0, 4.0)
+    clip.lens_pinhole_focal_length = (2.0, 4.0)
     clip.lens_focus_distance = (2, 4)
     clip.lens_entrance_pupil_offset = (1.23, 2.34)
     clip.lens_encoders = (FizEncoders(focus=0.1, iris=0.2, zoom=0.3),
@@ -211,7 +211,7 @@ class ModelTest(unittest.TestCase):
 
     self.assertTupleEqual(d["lens"]["tStop"], (2000, 4000))
     self.assertTupleEqual(d["lens"]["fStop"], (1200, 2800))
-    self.assertTupleEqual(d["lens"]["focalLength"], (2.0, 4.0))
+    self.assertTupleEqual(d["lens"]["pinholeFocalLength"], (2.0, 4.0))
     self.assertTupleEqual(d["lens"]["focusDistance"], (2, 4))
     self.assertTupleEqual(d["lens"]["entrancePupilOffset"], (1.23, 2.34))
     self.assertTupleEqual(d["lens"]["encoders"], ({ "focus":0.1, "iris":0.2, "zoom":0.3 },
@@ -366,21 +366,21 @@ class ModelTest(unittest.TestCase):
 
     self.assertTupleEqual(clip.lens_t_number, value)
 
-  def test_focal_length(self):
+  def test_pinhole_focal_length(self):
     clip = Clip()
 
-    self.assertIsNone(clip.lens_focal_length)
+    self.assertIsNone(clip.lens_pinhole_focal_length)
 
     with self.assertRaises(ValueError):
-      clip.lens_focal_length = 0
+      clip.lens_pinhole_focal_length = 0
     with self.assertRaises(ValueError):
-      clip.lens_focal_length = -1.0
+      clip.lens_pinhole_focal_length = -1.0
 
     value = (24.1, 24.2)
 
-    clip.lens_focal_length = value
+    clip.lens_pinhole_focal_length = value
 
-    self.assertTupleEqual(clip.lens_focal_length, value)
+    self.assertTupleEqual(clip.lens_pinhole_focal_length, value)
 
   def test_nominal_focal_length(self):
     clip = Clip()
@@ -390,11 +390,11 @@ class ModelTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       clip.lens_nominal_focal_length = [Fraction(5,7)]
 
-    value = (100, 7)
+    value = 100.0
 
-    clip.lens_focal_length = value
+    clip.lens_nominal_focal_length = value
 
-    self.assertTupleEqual(clip.lens_focal_length, value)
+    self.assertEqual(clip.lens_nominal_focal_length, value)
 
   def test_focus_position(self):
     clip = Clip()

--- a/src/test/python/test_mosys_reader.py
+++ b/src/test/python/test_mosys_reader.py
@@ -36,5 +36,5 @@ class MoSysReaderTest(unittest.TestCase):
     self.assertEqual(clip.lens_encoders[11], FizEncoders(focus=0.7643280029296875, zoom=0.0014190673828125))
     self.assertEqual(clip.lens_distortions[12], (Distortion([0.15680991113185883, -0.0881580114364624],None,None),))
     self.assertEqual(clip.lens_projection_offset[13], ProjectionOffset(-7.783590793609619, 6.896144866943359))
-    self.assertAlmostEqual(clip.lens_focal_length[14], 22.35, 2)
+    self.assertAlmostEqual(clip.lens_pinhole_focal_length[14], 22.35, 2)
     self.assertEqual(int(clip.lens_focus_distance[15]*1000), 2313)

--- a/src/test/python/test_red_reader.py
+++ b/src/test/python/test_red_reader.py
@@ -36,7 +36,7 @@ class REDReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.iso, 250)
 
-    self.assertEqual(clip.lens_focal_length[0], 40)
+    self.assertEqual(clip.lens_nominal_focal_length, 40)
 
     self.assertEqual(clip.lens_focus_distance[0], 410)
 

--- a/src/test/python/test_venice_reader.py
+++ b/src/test/python/test_venice_reader.py
@@ -39,7 +39,7 @@ class VeniceReaderTest(unittest.TestCase):
 
     self.assertEqual(clip.iso, 500)
 
-    self.assertEqual(clip.lens_focal_length[0], 32)
+    self.assertEqual(clip.lens_nominal_focal_length, 32)
 
     self.assertEqual(round(1000.0*clip.lens_t_number[0]), 2219)
 

--- a/src/test/resources/classic/subschemas/lens.json
+++ b/src/test/resources/classic/subschemas/lens.json
@@ -133,10 +133,10 @@
       "minimum": 0.0,
       "description": "The linear f-number of the lens, equal to the focal length divided\nby the diameter of the entrance pupil.\n"
     },
-    "focalLength": {
+    "pinholeFocalLength": {
       "type": "number",
       "minimum": 0.0,
-      "description": "Focal length of the lens.",
+      "description": "Distance between the pinhole and the image plane in the simple CGI pinhole camera model.",
       "units": "millimeter"
     },
     "focusDistance": {


### PR DESCRIPTION
This PR brings camdkit into line with OpenEXR and with the Cooke Optics paper on lens metadata vocabulary (to which some camdkit WG members contributed heavily)

Note that much of the FIZ data out there is providing nominal focal length; thus the readers will set a clip's `lens_nominal_focal_length` field if the returned "F" of FIZ is constant. If it's not constant, then it's likely describing the nominal focal length of a zoom lens, which OpenEXR describes as being "what's across from the index mark"; in that case, as `camdkit` doesn't currently support a time-varying nominal focal length, the nominal focal length field of the clip is not set.

I would be open to a suggestion to provide an average nominal focal length for zoom lenses if the largest difference between any two samples was less than 1mm but we could also do that in a 1.1 release.