### PR TITLE
Hoist frame_rate and sub_frame out of TimecodeFormat object into Timecode object

### DIFF
--- a/src/main/python/camdkit/examples.py
+++ b/src/main/python/camdkit/examples.py
@@ -7,7 +7,6 @@
 import uuid
 import copy
 
-from pydantic import JsonValue
 from pydantic.json_schema import JsonSchemaValue
 
 from camdkit.framework import *
@@ -154,7 +153,8 @@ def _get_recommended_dynamic_clip():
   # timing
   clip.timing_mode = (TimingMode.EXTERNAL,)
   clip.timing_sample_rate = (Fraction(24000, 1001),)
-  clip.timing_timecode = (Timecode(1,2,3,4,TimecodeFormat(frame_rate=Fraction(24000, 1001))),)
+  clip.timing_timecode = (Timecode(hours=1,minutes=2,seconds=3,frames=4,
+                                   frame_rate=StrictlyPositiveRational(24000, 1001)),)
   # transforms
   v, r = _example_transform_components()
   clip.transforms = ((Transform(translation=v, rotation=r, id="Camera"),),)

--- a/src/main/python/camdkit/framework.py
+++ b/src/main/python/camdkit/framework.py
@@ -8,8 +8,9 @@ from camdkit.lens_types import (FizEncoders, RawFizEncoders,
                                 ExposureFalloff,
                                 Distortion, DistortionOffset,
                                 ProjectionOffset)
+from camdkit.numeric_types import StrictlyPositiveRational
 from camdkit.timing_types import SynchronizationSource as SynchronizationSourceEnum
-from camdkit.timing_types import (PTPProfile, Timestamp, TimecodeFormat,
+from camdkit.timing_types import (PTPProfile, Timestamp,
                                   TimingMode, Timecode,
                                   SynchronizationOffsets, SynchronizationPTPPriorities, SynchronizationPTP,
                                   Synchronization)

--- a/src/main/python/camdkit/model.py
+++ b/src/main/python/camdkit/model.py
@@ -7,7 +7,6 @@ from camdkit.lens_types import ExposureFalloff as LensExposureFalloff
 from camdkit.lens_types import FizEncoders as LensEncoders
 from camdkit.lens_types import ProjectionOffset as LensProjectionOffset
 from camdkit.lens_types import RawFizEncoders as LensRawEncoders
-from camdkit.numeric_types import StrictlyPositiveRational
 from camdkit.timing_types import Synchronization
 from camdkit.timing_types import Timecode as TimingTimecode
 from camdkit.timing_types import Timestamp as TimingTimestamp

--- a/src/test/python/test_clip.py
+++ b/src/test/python/test_clip.py
@@ -17,7 +17,7 @@ from camdkit.lens_types import (ExposureFalloff,
                                 FizEncoders, RawFizEncoders)
 from camdkit.numeric_types import StrictlyPositiveRational
 from camdkit.camera_types import PhysicalDimensions, SenselDimensions
-from camdkit.timing_types import Timestamp, Timecode, TimecodeFormat, SynchronizationSource, \
+from camdkit.timing_types import Timestamp, Timecode, SynchronizationSource, \
     SynchronizationOffsets, SynchronizationPTP, Synchronization, PTPProfile, SynchronizationPTPPriorities
 from camdkit.transform_types import Vector3, Rotator3, Transform
 from camdkit.clip import Clip
@@ -310,12 +310,12 @@ class ClipTestCases(unittest.TestCase):
         timing_sequence_number = (0, 1)
         sample_rate = StrictlyPositiveRational(24000, 1001)
         timing_sample_rate = (sample_rate, sample_rate)
-        timecode0 = Timecode(1, 2, 3, 4,
-                            TimecodeFormat(frame_rate=StrictlyPositiveRational(24, 1),
-                                           sub_frame=0))
-        timecode1= Timecode(1, 2, 3, 5,
-                            TimecodeFormat(frame_rate=StrictlyPositiveRational(24, 1),
-                                           sub_frame=1))
+        timecode0 = Timecode(hours=1, minutes=2, seconds=3,frames=4,
+                            frame_rate=StrictlyPositiveRational(24, 1),
+                            sub_frame=0)
+        timecode1= Timecode(hours=1, minutes=2, seconds=3, frames=5,
+                            frame_rate=StrictlyPositiveRational(24, 1),
+                            sub_frame=1)
         timing_timecode = (timecode0, timecode1)
         ptp = SynchronizationPTP(profile=PTPProfile.SMPTE_2059_2_2021,
                                  domain=1,
@@ -370,10 +370,10 @@ class ClipTestCases(unittest.TestCase):
             {"num": 24000, "denom": 1001}))
         self.assertTupleEqual(clip_as_json["timing"]["timecode"], (
             {"hours":1, "minutes":2, "seconds":3, "frames":4,
-             "format": {"frameRate": {"num": 24, "denom": 1}}},
+             # no subFrame serialized because value was that of the default
+             "frameRate": {"num": 24, "denom": 1}},
             {"hours": 1,"minutes": 2,"seconds": 3,"frames": 5,
-             "format": {"frameRate": {"num": 24, "denom": 1},
-                        "subFrame": 1}}))
+             "frameRate": {"num": 24, "denom": 1}, "subFrame": 1}))
         expected_synchronization_dict = {
             "locked": True,
             "source": "ptp",

--- a/src/test/python/test_model.py
+++ b/src/test/python/test_model.py
@@ -7,9 +7,6 @@
 '''Generic camera classic tests'''
 
 import unittest
-from fractions import Fraction
-
-from pydantic import ValidationError
 
 from camdkit.framework import *
 from camdkit.model import *
@@ -87,8 +84,12 @@ class ModelTest(unittest.TestCase):
                                       Timestamp(1718806001, 0))
     clip.timing_sequence_number = (0,1)
     clip.timing_sample_rate = (Fraction(24000, 1001), Fraction(24000, 1001))
-    clip.timing_timecode = (Timecode(1,2,3,4,TimecodeFormat(frame_rate=24)),
-                            Timecode(1,2,3,5,TimecodeFormat(frame_rate=24)))
+    clip.timing_timecode = (Timecode(hours=1, minutes=2, seconds=3, frames=4,
+                                     frame_rate=StrictlyPositiveRational(24, 1),
+                                     sub_frame=0),
+                            Timecode(hours=1, minutes=2, seconds=3, frames=5,
+                                     frame_rate=StrictlyPositiveRational(24, 1),
+                                     sub_frame=0))
     sync = Synchronization(
       frequency=Fraction(24000, 1001),
       locked=True,
@@ -192,9 +193,9 @@ class ModelTest(unittest.TestCase):
     self.assertTupleEqual(d["timing"]["sampleRate"], ({ "num": 24000, "denom": 1001 }, { "num": 24000, "denom": 1001 }))
     self.assertTupleEqual(d["timing"]["timecode"],
                           ({ "hours":1,"minutes":2,"seconds":3,"frames":4,
-                             "format": { "frameRate": { "num": 24, "denom": 1 }}},
+                             "frameRate": { "num": 24, "denom": 1 }},
                            { "hours":1,"minutes":2,"seconds":3,"frames":5,
-                             "format": { "frameRate": { "num": 24, "denom": 1 }}}))
+                             "frameRate": { "num": 24, "denom": 1 }}))
     sync_dict = { "present":True,"locked":True,"frequency":{ "num": 24000, "denom": 1001 },"source":"ptp",
                   "ptp": {"profile": PTPProfile.SMPTE_2059_2_2021.value,
                           "domain":1,
@@ -639,7 +640,8 @@ class ModelTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       clip.timing_timecode = {1,2,3,24,"24"}
 
-    value = Timecode(1,2,3,4,TimecodeFormat(frame_rate=24))
+    value = Timecode(hours=1, minutes=2, seconds=3, frames=4,
+                     frame_rate=StrictlyPositiveRational(24, 1))
     clip.timing_timecode = (value,)
     self.assertEqual(clip.timing_timecode, (value,))
 
@@ -739,58 +741,62 @@ class ModelTest(unittest.TestCase):
     with self.assertRaises(ValueError):
         Timestamp(0,281474976710655)
 
-  def test_timecode_format(self):
-    self.assertEqual(TimecodeFormat(frame_rate=24).to_int(), 24)
-    self.assertEqual(TimecodeFormat(frame_rate=24, sub_frame=1).to_int(), 24)
-    self.assertEqual(TimecodeFormat(frame_rate=25).to_int(), 25)
-    self.assertEqual(TimecodeFormat(frame_rate=30).to_int(), 30)
-    self.assertEqual(TimecodeFormat(frame_rate=30, sub_frame=1).to_int(), 30)
-    with self.assertRaises(ValidationError):
-      TimecodeFormat()
-    with self.assertRaises(ValueError):
-      TimecodeFormat(frame_rate=0).to_int()
 
-  def test_timecode_formats(self):
-    with self.assertRaises(TypeError):
-      Timecode()
-    with self.assertRaises(TypeError):
-      Timecode(1,2,3)
-    with self.assertRaises(TypeError):
-      Timecode(0,0,0,0)
+  def test_timecode(self):
     with self.assertRaises(ValueError):
-      Timecode(0,0,0,0,TimecodeFormat(frame_rate=0))
-    self.assertTrue(TimingTimecode.validate(Timecode(0,0,0,0,TimecodeFormat(frame_rate=24))))
-    self.assertTrue(TimingTimecode.validate(Timecode(1,2,3,4,TimecodeFormat(frame_rate=24))))
-    self.assertTrue(TimingTimecode.validate(Timecode(23,59,59,23,TimecodeFormat(frame_rate=24))))
+      Timecode(hours=0, minutes=0, seconds=0, frames=0,
+               frame_rate=StrictlyPositiveRational(0,1),
+               sub_frame=0)
+    self.assertTrue(TimingTimecode.validate(Timecode(hours=0, minutes=0, seconds=0, frames=0,
+                                                     frame_rate=StrictlyPositiveRational(24, 1))))
+    self.assertTrue(TimingTimecode.validate(Timecode(hours=1, minutes=2, seconds=3, frames=4,
+                                                     frame_rate=StrictlyPositiveRational(24, 1))))
+    self.assertTrue(TimingTimecode.validate(Timecode(hours=23, minutes=59, seconds=59, frames=23,
+                                                     frame_rate=StrictlyPositiveRational(24, 1))))
     with self.assertRaises(ValueError):
-        Timecode(-1,2,3,4,TimecodeFormat(frame_rate=24))
+        Timecode(hours=-1, seconds=2, minutes=3, frames=4,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(24,2,3,4,TimecodeFormat(frame_rate=24))
+        Timecode(hours=24, seconds=2, minutes=3, frames=4,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(1,-1,3,4,TimecodeFormat(frame_rate=24))
+        Timecode(hours=1, seconds=-1, minutes=3, frames=4,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(1,60,3,4,TimecodeFormat(frame_rate=24))
+        Timecode(hours=1, seconds=60, minutes=3, frames=4,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(1,2,-1,4,TimecodeFormat(frame_rate=24))
+        Timecode(hours=1, seconds=2, minutes=-1, frames=4,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(1,2,60,4,TimecodeFormat(frame_rate=24))
+        Timecode(hours=1, seconds=2, minutes=60, frames=4,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(1,2,3,-1,TimecodeFormat(frame_rate=24))
+        Timecode(hours=1, seconds=2, minutes=3, frames=-1,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(1,2,3,24,TimecodeFormat(frame_rate=24))
+        Timecode(hours=1, seconds=2, minutes=3, frames=24,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(1,2,3,24,TimecodeFormat(frame_rate=24, sub_frame=1))
+        Timecode(hours=1, seconds=2, minutes=3, frames=24,
+        frame_rate=StrictlyPositiveRational(24, 1), sub_frame=1)
     with self.assertRaises(ValueError):
-        Timecode(1,2,3,25,TimecodeFormat(frame_rate=25))
+        Timecode(hours=1, seconds=2, minutes=3, frames=25,
+        frame_rate=StrictlyPositiveRational(25, 1), sub_frame=1)
     with self.assertRaises(ValueError):
-        Timecode(1,2,3,30,TimecodeFormat(frame_rate=30))
+        Timecode(hours=1, seconds=2, minutes=3, frames=30,
+        frame_rate=StrictlyPositiveRational(30, 1), sub_frame=1)
     with self.assertRaises(ValueError):
-        Timecode(1,2,3,30,TimecodeFormat(frame_rate=30, sub_frame=1))
-    self.assertTrue(TimingTimecode.validate(Timecode(1,2,3,119,TimecodeFormat(frame_rate=120))))
+        Timecode(hours=1, seconds=2, minutes=3, frames=30,
+        frame_rate=StrictlyPositiveRational(30, 1), sub_frame=1)
+    self.assertTrue(TimingTimecode.validate(Timecode(hours=1, minutes=2, seconds=3, frames=119,
+                                                     frame_rate=StrictlyPositiveRational(120, 1), sub_frame=0)))
     with self.assertRaises(ValueError):
-        Timecode(1,2,3,120,TimecodeFormat(frame_rate=120))
+        Timecode(hours=1, seconds=2, minutes=3, frames=120,
+        frame_rate=StrictlyPositiveRational(120, 1), sub_frame=0)
     with self.assertRaises(ValueError):
-        Timecode(1,2,3,120,TimecodeFormat(frame_rate=121))
+        Timecode(hours=1, seconds=2, minutes=3, frames=120,
+        frame_rate=StrictlyPositiveRational(121, 1), sub_frame=0)
 
   def test_timecode_from_dict(self):
     r = TimingTimecode.from_json({
@@ -798,28 +804,43 @@ class ModelTest(unittest.TestCase):
       "minutes": 2,
       "seconds": 3,
       "frames": 4,
-      "format": {
-        "frameRate": {
+      "frameRate": {
           "num": 24,
           "denom": 1
         },
-        "subFrame": 0,
-      }
+      "subFrame": 0,
     })
-    self.assertEqual(str(r), str(Timecode(1,2,3,4,TimecodeFormat(frame_rate=24))))
+    self.assertEqual(str(r), str(Timecode(hours=1, minutes=2, seconds=3, frames=4,
+                                          frame_rate=StrictlyPositiveRational(24, 1),
+                                          sub_frame=0)))
 
   def test_timecode_to_dict(self):
-    j = TimingTimecode.to_json(Timecode(1,2,3,4,TimecodeFormat(frame_rate=24)))
-    self.assertDictEqual(j, {
+    j0 = TimingTimecode.to_json(Timecode(hours=1, minutes=2, seconds=3, frames=4,
+                                        frame_rate=StrictlyPositiveRational(24, 1),
+                                        sub_frame=0))
+    # since the explicit sub_frame of zero matches the default, it isn't serialized
+    self.assertDictEqual(j0, {
       "hours": 1,
       "minutes": 2,
       "seconds": 3,
       "frames": 4,
-      "format": {
-        "frameRate": {
+      "frameRate": {
           "num": 24,
           "denom": 1
-        }}})
+        }})
+    j1 = TimingTimecode.to_json(Timecode(hours=1, minutes=2, seconds=3, frames=4,
+                                         frame_rate=StrictlyPositiveRational(24, 1),
+                                         sub_frame=1))
+    self.assertDictEqual(j1, {
+      "hours": 1,
+      "minutes": 2,
+      "seconds": 3,
+      "frames": 4,
+      "frameRate": {
+        "num": 24,
+        "denom": 1
+      },
+      "subFrame": 1})
 
   def test_lens_encoders_limits(self):
     clip = Clip()

--- a/src/test/python/test_mosys_reader.py
+++ b/src/test/python/test_mosys_reader.py
@@ -9,8 +9,10 @@
 import unittest
 import uuid
 
-from camdkit.framework import Vector3, Rotator3, Synchronization, SynchronizationSourceEnum, \
-                              Timecode, TimecodeFormat, FizEncoders, Distortion, ProjectionOffset
+from camdkit.framework import (Vector3, Rotator3,
+                               Synchronization, SynchronizationSourceEnum,
+                               Timecode, StrictlyPositiveRational,
+                               FizEncoders, Distortion, ProjectionOffset)
 from camdkit.model import OPENTRACKIO_PROTOCOL_NAME, OPENTRACKIO_PROTOCOL_VERSION
 from camdkit.mosys import reader
 
@@ -30,7 +32,10 @@ class MoSysReaderTest(unittest.TestCase):
     self.assertEqual(clip.timing_sequence_number[6], 13)
     self.assertEqual(clip.timing_synchronization[7],
                      Synchronization(frequency=25, locked=True, source=SynchronizationSourceEnum.GENLOCK, ptp=None, present=True))
-    self.assertEqual(str(clip.timing_timecode[8]), str(Timecode(15,3,47,10,TimecodeFormat(frame_rate=25))))
+    self.assertEqual(str(clip.timing_timecode[8]),
+                     str(Timecode(hours=15, minutes=3, seconds=47, frames=10,
+                                  frame_rate=StrictlyPositiveRational(25,1),
+                                  sub_frame=0)))
     self.assertEqual(clip.transforms[9][0].translation, Vector3(x=-8.121, y=-185.368, z=119.806))
     self.assertEqual(clip.transforms[10][0].rotation, Rotator3(pan=-2.969, tilt=-28.03, roll=3.1))
     self.assertEqual(clip.lens_encoders[11], FizEncoders(focus=0.7643280029296875, zoom=0.0014190673828125))

--- a/src/test/resources/classic/subschemas/timing.json
+++ b/src/test/resources/classic/subschemas/timing.json
@@ -164,14 +164,6 @@
               ],
               "type": "object"
             },
-            "timeSource": {
-              "enum": [
-                "GNSS",
-                "Atomic clock",
-                "NTP"
-              ],
-              "type": "string"
-            },
             "meanPathDelay": {
               "minimum": 0.0,
               "type": "number"
@@ -181,6 +173,14 @@
                 "IEEE Std 1588-2019",
                 "IEEE Std 802.1AS-2020",
                 "SMPTE ST2059-2:2021"
+              ],
+              "type": "string"
+            },
+            "timeSource": {
+              "enum": [
+                "GNSS",
+                "Atomic clock",
+                "NTP"
               ],
               "type": "string"
             },
@@ -218,40 +218,25 @@
     },
     "timecode": {
       "additionalProperties": false,
-      "description": "SMPTE timecode of the sample. Timecode is a standard for labeling\nindividual frames of data in media systems and is useful for\ninter-frame synchronization.\n- format.frameRate: The frame rate as a rational number. Drop frame\nrates such as 29.97 should be represented as e.g. 30000/1001. The\ntimecode frame rate may differ from the sample frequency.\n",
+      "description": "SMPTE timecode of the sample. Timecode is a standard for labeling\nindividual frames of data in media systems and is useful for\ninter-frame synchronization. Frame rate is a rational number, allowing\ndrop frame rates such as that colloquially called 29.97 to be\nrepresented exactly, as 30000/1001. The timecode frame rate may differ\nfrom the sample frequency. The zero-based sub-frame field allows for finer\ndivision of the frame, e.g. interlaced frames have two sub-frames,\none per field.\n",
       "properties": {
-        "format": {
+        "frameRate": {
           "additionalProperties": false,
-          "description": "The timecode format is defined as a rational frame rate and - where a\nsignal with sub-frames is described, such as an interlaced signal - an\nindex of which sub-frame is referred to by the timecode.\n",
           "properties": {
-            "frameRate": {
-              "additionalProperties": false,
-              "properties": {
-                "denom": {
-                  "maximum": 4294967295,
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "num": {
-                  "maximum": 2147483647,
-                  "minimum": 1,
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "num",
-                "denom"
-              ],
-              "type": "object"
-            },
-            "subFrame": {
+            "denom": {
               "maximum": 4294967295,
-              "minimum": 0,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "num": {
+              "maximum": 2147483647,
+              "minimum": 1,
               "type": "integer"
             }
           },
           "required": [
-            "frameRate"
+            "num",
+            "denom"
           ],
           "type": "object"
         },
@@ -274,6 +259,11 @@
           "maximum": 59,
           "minimum": 0,
           "type": "integer"
+        },
+        "subFrame": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
         }
       },
       "required": [
@@ -281,7 +271,7 @@
         "minutes",
         "seconds",
         "frames",
-        "format"
+        "frameRate"
       ],
       "type": "object"
     }


### PR DESCRIPTION
In the process, change undefined behavior to `ValueError` when F4 reader encounters unknown frame rate. 