### PR TITLE
Add to_pseudo_frame_json in clip

### DIFF
--- a/src/main/python/camdkit/clip.py
+++ b/src/main/python/camdkit/clip.py
@@ -18,6 +18,7 @@ from camdkit.compatibility import (CompatibleBaseModel,
                                    ARRAY,
                                    GLOBAL_POSITION,
                                    TRANSFORMS)
+from camdkit.utils import unwrap_clip_to_pseudo_frame
 from camdkit.units import METER, METERS_AND_DEGREES, SECOND
 from camdkit.numeric_types import (NonNegativeInt,
                                    StrictlyPositiveRational,
@@ -291,11 +292,14 @@ class Clip(CompatibleBaseModel):
         Clip.traverse_json_schema(Clip, full_schema, ('',), extractor)
         return result
 
-    def to_json(self, i: Optional[int] = None) -> Self:
+    def to_json(self, i: Optional[int] = None) -> dict:
         if i != None:
             single_frame_clip: Self =  self[i]
             return CompatibleBaseModel.to_json(single_frame_clip)
         return CompatibleBaseModel.to_json(self)
+
+    def to_pseudo_frame_json(self, i: int) -> JsonSchemaValue:
+        return unwrap_clip_to_pseudo_frame(self.to_json(i))
 
     def _print_non_none(self):
         full_schema = Clip.make_json_schema(mode='validation', exclude_camdkit_internals=False)

--- a/src/main/python/camdkit/compatibility.py
+++ b/src/main/python/camdkit/compatibility.py
@@ -9,7 +9,7 @@
 import jsonref
 
 from abc import abstractmethod
-from typing import Final, Any, Self
+from typing import Final, Any, Self, overload
 from copy import deepcopy
 
 from pydantic import BaseModel, ValidationError, ConfigDict
@@ -280,6 +280,14 @@ class CompatibleBaseModel(BaseModel):
             return True
         except ValidationError:
             return False
+
+    @overload
+    @classmethod
+    def to_json(cls, model_or_tuple: Self) -> dict: ...
+
+    @overload
+    @classmethod
+    def to_json(cls, model_or_tuple: tuple) -> tuple: ...
 
     @classmethod
     def to_json(cls, model_or_tuple: Self | tuple):

--- a/src/main/python/camdkit/examples.py
+++ b/src/main/python/camdkit/examples.py
@@ -5,71 +5,18 @@
 # Copyright Contributors to the SMTPE RIS OSVP Metadata Project
 
 import uuid
-import copy
 
 from pydantic.json_schema import JsonSchemaValue
 
 from camdkit.framework import *
 from camdkit.model import Clip, OPENTRACKIO_PROTOCOL_NAME, OPENTRACKIO_PROTOCOL_VERSION
 from camdkit.timing_types import TimingMode, SynchronizationPTPPriorities, PTPLeaderTimeSource
-
-
-def _unwrap_clip_to_pseudo_frame(wrapped_clip: JsonSchemaValue) -> JsonSchemaValue:
-  paths_to_unwrap: tuple[tuple[str, ...], ...] = (
-    ("globalStage",),
-    ("lens", "custom"),
-    ("lens", "distortion"),
-    ("lens", "distortionOffset"),
-    ("lens", "distortionOverscan"),
-    ("lens", "encoders"),
-    ("lens", "entrancePupilOffset"),
-    ("lens", "exposureFalloff"),
-    ("lens", "fStop"),
-    ("lens", "pinholeFocalLength"),
-    ("lens", "focusDistance"),
-    ("lens", "projectionOffset"),
-    ("lens", "rawEncoders"),
-    ("lens", "tStop"),
-    ("lens", "undistortionOverscan"),
-    ("protocol",),
-    ("relatedSampleIds",),
-    ("sampleId",),
-    ("sourceId",),
-    ("sourceNumber",),
-    ("timing", "mode"),
-    ("timing", "recordedTimestamp"),
-    ("timing", "sampleRate"),
-    ("timing", "sampleTimestamp"),
-    ("timing", "sequenceNumber"),
-    ("timing", "synchronization"),
-    ("timing", "timecode"),
-    ("tracker", "notes"),
-    ("tracker", "recording"),
-    ("tracker", "slate"),
-    ("tracker", "status"),
-    ("transforms",)
-  )
-  clip = copy.deepcopy(wrapped_clip)
-  for path in paths_to_unwrap:
-    # REALLY brute-force
-    if len(path) == 1:
-      k0 = path[0]
-      if k0 in clip:
-        clip[k0] = clip[k0][0]
-    elif len(path) == 2:
-      k0 = path[0]
-      if k0 in clip:
-        k1 = path[1]
-        if k1 in clip[k0]:
-          clip[k0][k1] = clip[k0][k1][0]
-    else:
-      raise RuntimeError("That's too deep for me I'm afraid")
-  return clip
+from camdkit.utils import unwrap_clip_to_pseudo_frame
 
 
 def get_recommended_static_example():
   clip = _get_recommended_static_clip()
-  return  _unwrap_clip_to_pseudo_frame(clip.to_json(0))
+  return  unwrap_clip_to_pseudo_frame(clip.to_json(0))
 
 def get_complete_static_example():
   clip = _get_complete_static_clip()
@@ -79,7 +26,7 @@ def get_complete_static_example():
     "pot1": 2435,
     "button1": False
   }
-  return _unwrap_clip_to_pseudo_frame(clip_json)
+  return unwrap_clip_to_pseudo_frame(clip_json)
 
 def _add_recommended_static_clip_parameters(clip: Clip) -> Clip:
   clip.camera_label = "A"
@@ -122,7 +69,7 @@ def _get_complete_static_clip() -> Clip:
 
 def get_recommended_dynamic_example():
   clip = _get_recommended_dynamic_clip()
-  return _unwrap_clip_to_pseudo_frame(clip.to_json(0))
+  return unwrap_clip_to_pseudo_frame(clip.to_json(0))
 
 def get_complete_dynamic_example():
   clip = _get_complete_dynamic_clip()
@@ -133,7 +80,7 @@ def get_complete_dynamic_example():
     "pot1": 2435,
     "button1": False
   }
-  return _unwrap_clip_to_pseudo_frame(clip_json)
+  return unwrap_clip_to_pseudo_frame(clip_json)
 
 def _example_transform_components() -> tuple[Vector3, Rotator3]:
   return Vector3(x=1.0, y=2.0, z=3.0), Rotator3(pan=180.0, tilt=90.0, roll=45.0)

--- a/src/main/python/camdkit/examples.py
+++ b/src/main/python/camdkit/examples.py
@@ -11,22 +11,20 @@ from pydantic.json_schema import JsonSchemaValue
 from camdkit.framework import *
 from camdkit.model import Clip, OPENTRACKIO_PROTOCOL_NAME, OPENTRACKIO_PROTOCOL_VERSION
 from camdkit.timing_types import TimingMode, SynchronizationPTPPriorities, PTPLeaderTimeSource
-from camdkit.utils import unwrap_clip_to_pseudo_frame
 
 
 def get_recommended_static_example():
   clip = _get_recommended_static_clip()
-  return  unwrap_clip_to_pseudo_frame(clip.to_json(0))
+  return clip.to_pseudo_frame_json(0)
 
 def get_complete_static_example():
   clip = _get_complete_static_clip()
-  clip_json = clip.to_json(0)
-  # Add additional custom data
+  clip_json = clip.to_pseudo_frame_json(0)
   clip_json["custom"] = {
     "pot1": 2435,
     "button1": False
   }
-  return unwrap_clip_to_pseudo_frame(clip_json)
+  return clip_json
 
 def _add_recommended_static_clip_parameters(clip: Clip) -> Clip:
   clip.camera_label = "A"
@@ -69,18 +67,16 @@ def _get_complete_static_clip() -> Clip:
 
 def get_recommended_dynamic_example():
   clip = _get_recommended_dynamic_clip()
-  return unwrap_clip_to_pseudo_frame(clip.to_json(0))
+  return clip.to_pseudo_frame_json(0)
 
 def get_complete_dynamic_example():
   clip = _get_complete_dynamic_clip()
-  clip_json = clip.to_json(0)
-
-  # Add additional custom data
+  clip_json = clip.to_pseudo_frame_json(0)
   clip_json["custom"] = {
     "pot1": 2435,
     "button1": False
   }
-  return unwrap_clip_to_pseudo_frame(clip_json)
+  return clip_json
 
 def _example_transform_components() -> tuple[Vector3, Rotator3]:
   return Vector3(x=1.0, y=2.0, z=3.0), Rotator3(pan=180.0, tilt=90.0, roll=45.0)

--- a/src/main/python/camdkit/utils.py
+++ b/src/main/python/camdkit/utils.py
@@ -6,8 +6,11 @@
 
 """Utility functions"""
 
-from fractions import Fraction
+import copy
 import numbers
+from fractions import Fraction
+
+from pydantic.json_schema import JsonSchemaValue
 
 _WELL_KNOWN_FRACTIONAL_FPS = set([Fraction(24000, 1001), Fraction(30000, 1001), Fraction(60000, 1001), Fraction(120000, 1001)])
 _FPS_THRESHOLD = 0.01
@@ -38,3 +41,55 @@ def guess_fps(fps: numbers.Real) -> Fraction:
       return wkfps
 
   raise ValueError("Not a valid FPS")
+
+def unwrap_clip_to_pseudo_frame(wrapped_clip: JsonSchemaValue) -> JsonSchemaValue:
+  paths_to_unwrap: tuple[tuple[str, ...], ...] = (
+    ("globalStage",),
+    ("lens", "custom"),
+    ("lens", "distortion"),
+    ("lens", "distortionOffset"),
+    ("lens", "distortionOverscan"),
+    ("lens", "encoders"),
+    ("lens", "entrancePupilOffset"),
+    ("lens", "exposureFalloff"),
+    ("lens", "fStop"),
+    ("lens", "pinholeFocalLength"),
+    ("lens", "focusDistance"),
+    ("lens", "projectionOffset"),
+    ("lens", "rawEncoders"),
+    ("lens", "tStop"),
+    ("lens", "undistortionOverscan"),
+    ("protocol",),
+    ("relatedSampleIds",),
+    ("sampleId",),
+    ("sourceId",),
+    ("sourceNumber",),
+    ("timing", "mode"),
+    ("timing", "recordedTimestamp"),
+    ("timing", "sampleRate"),
+    ("timing", "sampleTimestamp"),
+    ("timing", "sequenceNumber"),
+    ("timing", "synchronization"),
+    ("timing", "timecode"),
+    ("tracker", "notes"),
+    ("tracker", "recording"),
+    ("tracker", "slate"),
+    ("tracker", "status"),
+    ("transforms",)
+  )
+  clip = copy.deepcopy(wrapped_clip)
+  for path in paths_to_unwrap:
+    # REALLY brute-force
+    if len(path) == 1:
+      k0 = path[0]
+      if k0 in clip:
+        clip[k0] = clip[k0][0]
+    elif len(path) == 2:
+      k0 = path[0]
+      if k0 in clip:
+        k1 = path[1]
+        if k1 in clip[k0]:
+          clip[k0][k1] = clip[k0][k1][0]
+    else:
+      raise RuntimeError("That's too deep for me I'm afraid")
+  return clip

--- a/src/test/python/test_clip.py
+++ b/src/test/python/test_clip.py
@@ -505,6 +505,35 @@ class ClipTestCases(unittest.TestCase):
         #     for doc_entry in sorted_doc:
         #         print_doc_entry(doc_entry, fp)
 
+    def test_to_pseudo_frame_json(self):
+        f_number: Final[tuple[float, ...]] = (4.0,)
+        global_stage: Final[tuple[GlobalPosition, ...]] = (
+            GlobalPosition(100.0, 200.0, 300.0, 100.0, 200.0, 300.0),
+        )
+        sample_id: Final[tuple[str, ...]] = (VALID_SAMPLE_ID,)
+        global_stage_dict: Final[dict] = {
+            "E": 100.0, "N": 200.0, "U": 300.0,
+            "lat0": 100.0, "lon0": 200.0, "h0": 300.0,
+        }
+
+        clip = Clip()
+        clip.lens_f_number = f_number
+        clip.global_stage = global_stage
+        clip.sample_id = sample_id
+
+        framed = clip.to_json(0)
+        pseudo = clip.to_pseudo_frame_json(0)
+
+        self.assertIsInstance(pseudo, dict)
+        # Frame-array form keeps single-frame fields as 1-element tuples
+        self.assertTupleEqual(framed["lens"]["fStop"], f_number)
+        self.assertTupleEqual(framed["sampleId"], sample_id)
+        self.assertTupleEqual(framed["globalStage"], (global_stage_dict,))
+        # Pseudo-frame form unwraps them to scalars / dicts
+        self.assertEqual(pseudo["lens"]["fStop"], 4.0)
+        self.assertEqual(pseudo["sampleId"], VALID_SAMPLE_ID)
+        self.assertEqual(pseudo["globalStage"], global_stage_dict)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/python/test_example_regression.py
+++ b/src/test/python/test_example_regression.py
@@ -13,7 +13,7 @@ from typing import Literal
 
 from pydantic.json_schema import JsonSchemaValue
 
-from camdkit.examples import _unwrap_clip_to_pseudo_frame
+from camdkit.utils import unwrap_clip_to_pseudo_frame
 
 CLASSIC = Path("src/test/resources/classic")
 CLASSIC_EXAMPLES_DIR: Path = CLASSIC / "examples"
@@ -62,7 +62,7 @@ def generify_urn_uuids(clip: JsonSchemaValue) -> None:
 #             "globalStage": "foo",
 #             "lens": { "distortion": 4.1}
 #         }
-#         corrupted_clip = _unwrap_clip_to_pseudo_frame(deepcopy(good_clip))
+#         corrupted_clip = unwrap_clip_to_pseudo_frame(deepcopy(good_clip))
 #         self.assertEqual(pseudo_frame, corrupted_clip)
 #
 #     def compare(self, completeness: Literal['recommended', 'complete'],


### PR DESCRIPTION
# Add Clip.to_pseudo_frame_json

## Summary

camdkit's `Clip.to_json()` emits frame-array format (each parameter wrapped
in a per-frame tuple), but OpenTrackIO consumers expect a single-frame
payload with scalar values. There was no built-in way to produce that
shape, so callers had to reach into the private `_unwrap_clip_to_pseudo_frame`
in `examples.py`.

This PR:
- Promotes `_unwrap_clip_to_pseudo_frame` from `examples.py` to a public
  `unwrap_clip_to_pseudo_frame` in `utils.py`.
- Adds `Clip.to_pseudo_frame_json(i)` which returns an OpenTrackIO-shaped
  dict for frame `i`.
- Fixes the return annotation of `Clip.to_json` (was `Self`, now `dict`).
