### PR TITLE
Update the examples with the latest schema v1.0.1

### DIFF
--- a/src/test/resources/classic/examples/complete_dynamic_example.json
+++ b/src/test/resources/classic/examples/complete_dynamic_example.json
@@ -12,8 +12,8 @@
       "nanoseconds": 500000000
     },
     "sampleRate": {
-      "num": 24000,
-      "denom": 1001
+      "num": 24,
+      "denom": 1
     },
     "sampleTimestamp": {
       "seconds": 1718806554,
@@ -50,7 +50,9 @@
       "frameRate": {
         "num": 24000,
         "denom": 1001
-      }
+      },
+      "subFrame": 1,
+      "dropFrame": true
     }
   },
   "lens": {
@@ -123,17 +125,17 @@
   "protocol": {
     "name": "OpenTrackIO",
     "version": [
+      1,
       0,
-      9,
-      3
+      1
     ]
   },
-  "sampleId": "urn:uuid:a4034319-eea8-4fb5-9567-90047d82bbf1",
-  "sourceId": "urn:uuid:fc9bc480-02bd-4bd0-96c7-bce47197f720",
+  "sampleId": "urn:uuid:d637c435-d6f8-4851-931f-7f9c7487f311",
+  "sourceId": "urn:uuid:a10843bc-95fd-46b1-a8d3-bb79f01da177",
   "sourceNumber": 1,
   "relatedSampleIds": [
-    "urn:uuid:5210332e-0292-4f8e-a606-a23ebe2ae18e",
-    "urn:uuid:1cc04717-7d46-4d0b-ad42-5c0d8c1a5c40"
+    "urn:uuid:51d3eb3d-df3a-4994-8072-5bc7e62848d8",
+    "urn:uuid:a3b2b8fe-65af-487e-85ae-7a56bdc86d9b"
   ],
   "globalStage": {
     "E": 100.0,

--- a/src/test/resources/classic/examples/complete_static_example.json
+++ b/src/test/resources/classic/examples/complete_static_example.json
@@ -27,7 +27,7 @@
         "denom": 1
       },
       "isoSpeed": 4000,
-      "fdlLink": "urn:uuid:62ea03ac-ce56-43c6-ab8d-a9ec8a9ee7b3",
+      "fdlLink": "urn:uuid:30bdf4bb-e21c-45fb-a7f9-030f3abd9b61",
       "shutterAngle": 45.0
     },
     "lens": {
@@ -62,8 +62,8 @@
       "nanoseconds": 500000000
     },
     "sampleRate": {
-      "num": 24000,
-      "denom": 1001
+      "num": 24,
+      "denom": 1
     },
     "sampleTimestamp": {
       "seconds": 1718806554,
@@ -100,7 +100,9 @@
       "frameRate": {
         "num": 24000,
         "denom": 1001
-      }
+      },
+      "subFrame": 1,
+      "dropFrame": true
     }
   },
   "lens": {
@@ -173,17 +175,17 @@
   "protocol": {
     "name": "OpenTrackIO",
     "version": [
+      1,
       0,
-      9,
-      3
+      1
     ]
   },
-  "sampleId": "urn:uuid:e3f34dae-b68c-47d9-99af-e0bfc277723c",
-  "sourceId": "urn:uuid:889eec71-62ca-4c7f-b1ef-4c2b16f4eacf",
+  "sampleId": "urn:uuid:25a3119d-03b5-4d15-b4f8-904f43e90048",
+  "sourceId": "urn:uuid:8586316a-abd9-4454-ab5e-4c83dfb87837",
   "sourceNumber": 1,
   "relatedSampleIds": [
-    "urn:uuid:b545b989-34b2-452a-9630-cf952d021a3f",
-    "urn:uuid:dd8ce967-21f2-444e-a007-5eb33333ca51"
+    "urn:uuid:c1ef855c-0c47-4db4-bd38-111ae234b771",
+    "urn:uuid:52bd25b4-da7d-4ec7-8f18-a13e645ff2c8"
   ],
   "globalStage": {
     "E": 100.0,

--- a/src/test/resources/classic/examples/recommended_dynamic_example.json
+++ b/src/test/resources/classic/examples/recommended_dynamic_example.json
@@ -8,8 +8,8 @@
   "timing": {
     "mode": "external",
     "sampleRate": {
-      "num": 24000,
-      "denom": 1001
+      "num": 24,
+      "denom": 1
     },
     "timecode": {
       "hours": 1,
@@ -17,8 +17,8 @@
       "seconds": 3,
       "frames": 4,
       "frameRate": {
-        "num": 24000,
-        "denom": 1001
+        "num": 24,
+        "denom": 1
       }
     }
   },
@@ -54,13 +54,13 @@
   "protocol": {
     "name": "OpenTrackIO",
     "version": [
+      1,
       0,
-      9,
-      3
+      1
     ]
   },
-  "sampleId": "urn:uuid:cd5677eb-b18d-4746-9dc3-2890c0711d52",
-  "sourceId": "urn:uuid:cd3713e1-cc63-4d7e-83d7-c984a6395d5f",
+  "sampleId": "urn:uuid:aff9cd2f-e86f-4870-bcc2-c71a26decd34",
+  "sourceId": "urn:uuid:21d2fdf3-f13e-48f3-9706-185829f00ca5",
   "sourceNumber": 1,
   "transforms": [
     {

--- a/src/test/resources/classic/examples/recommended_static_example.json
+++ b/src/test/resources/classic/examples/recommended_static_example.json
@@ -21,8 +21,8 @@
   "timing": {
     "mode": "external",
     "sampleRate": {
-      "num": 24000,
-      "denom": 1001
+      "num": 24,
+      "denom": 1
     },
     "timecode": {
       "hours": 1,
@@ -30,8 +30,8 @@
       "seconds": 3,
       "frames": 4,
       "frameRate": {
-        "num": 24000,
-        "denom": 1001
+        "num": 24,
+        "denom": 1
       }
     }
   },
@@ -67,13 +67,13 @@
   "protocol": {
     "name": "OpenTrackIO",
     "version": [
+      1,
       0,
-      9,
-      3
+      1
     ]
   },
-  "sampleId": "urn:uuid:582cbfff-b9c4-4978-8a5e-45bf519e4a89",
-  "sourceId": "urn:uuid:327811dd-4d85-4e2e-9721-9ceb1d252a17",
+  "sampleId": "urn:uuid:37740aab-d778-49b1-9fc7-4ecd94ed1dde",
+  "sourceId": "urn:uuid:4d079615-4858-403f-97b9-7b60d5ba2c51",
   "sourceNumber": 1,
   "transforms": [
     {


### PR DESCRIPTION
# Update the examples with the latest schema v1.0.1

## Summary

Update the outdated examples with the new generated example using the latest schema (`v1.0.1`).