### PR TITLE
Fix off-by-one in Mo-Sys reader to_clip frame count

### DIFF
--- a/src/main/python/camdkit/mosys/reader.py
+++ b/src/main/python/camdkit/mosys/reader.py
@@ -28,7 +28,7 @@ def to_clip(filename: str, frames: int = -1) -> Clip:
     offset = 0
     success = True
     count = 0
-    while success and (frames == -1 or (count <= frames)):
+    while success and (frames == -1 or (count < frames)):
       success, frame, packet_size = to_frame(data[offset:])
       if success:
         if offset == 0:


### PR DESCRIPTION
# Fix off-by-one in Mo-Sys reader to_clip frame count

## Summary

The loop condition `count <= frames` caused `to_clip` to read one frame more than requested.
Changed to `count < frames` so the returned clip contains exactly `frames` frames.