### PR TITLE
fix: BMD reader raises string literal instead of ValueError when no frame data

### DIFF
--- a/src/main/python/camdkit/bmd/reader.py
+++ b/src/main/python/camdkit/bmd/reader.py
@@ -42,7 +42,7 @@ def to_clip(metadata_file: typing.IO) -> camdkit.model.Clip:
 
 
   if len(frame_data) == 0:
-    raise "Camera data does not contain frame information"
+    raise ValueError("Camera data does not contain frame information")
 
   # read clip metadata
   clip = camdkit.model.Clip()

--- a/src/test/python/test_bmd_reader.py
+++ b/src/test/python/test_bmd_reader.py
@@ -6,6 +6,7 @@
 
 '''Blackmagic camera RAW reader tests'''
 
+import io
 import unittest
 
 import camdkit.bmd.reader
@@ -50,3 +51,8 @@ class BMDReaderTest(unittest.TestCase):
     self.assertEqual(clip.lens_t_number[0], 2.3)
 
     self.assertEqual(clip.shutter_angle, 180)
+
+  def test_no_frames_raises_value_error(self):
+    clip_only = io.StringIO("Clip Metadata\nmanufacturer: Blackmagic Design\n")
+    with self.assertRaises(ValueError):
+      camdkit.bmd.reader.to_clip(clip_only)


### PR DESCRIPTION
## Summary

`bmd/reader.py` raises a string literal instead of a proper exception when the
input file contains no frame sections. In Python 3, `raise <non-exception>` is
itself a TypeError, so callers receive the wrong exception type with no useful
message.

## Demonstration

BEFORE — calling to_clip() on a file with only clip-level metadata:
  TypeError: exceptions must derive from BaseException

AFTER:
  ValueError: Camera data does not contain frame information

## Impact

Any caller that catches ValueError to handle bad input will not catch
the TypeError that is actually raised. The error message is also lost,
making the failure harder to diagnose.

## Change

bmd/reader.py: `raise "..."` → `raise ValueError("...")`
test_bmd_reader.py: add test covering the no-frame-data path

## Found via

Static code audit of the reader module.