### PR TITLE
fix: get_focal_length reads lens.pinholeFocalLength not lens.focalLength

### DIFF
--- a/src/test/python/parser/opentrackio_lib.py
+++ b/src/test/python/parser/opentrackio_lib.py
@@ -404,8 +404,8 @@ class OpenTrackIOProtocol:
 
     def get_focal_length(self):
         """Return the current lens focal length"""
-        if self.validate_dict_elements(self.pd,["lens","focalLength"]):
-            return self.pd["lens"]["focalLength"]
+        if self.validate_dict_elements(self.pd,["lens","pinholeFocalLength"]):
+            return self.pd["lens"]["pinholeFocalLength"]
         else:
             return None
 


### PR DESCRIPTION
## Summary

`get_focal_length()` in `opentrackio_lib.py` reads the key `lens.focalLength`, which does not exist in the v1.0.1 schema. The correct key is `lens.pinholeFocalLength`. Because the key is never found, `validate_dict_elements` always returns `False` and the method always returns `None` silently, with no error.

## Demonstration

BEFORE: `get_focal_length()` on any valid v1.0.1 payload
  returns None (key `lens.focalLength` absent from schema)

AFTER:
  returns the correct float value from `lens.pinholeFocalLength`

## Impact

Any caller of `get_focal_length()` receives `None` for every valid payload, regardless of what focal length the payload contains.

## Change

`opentrackio_lib.py`: replace `"focalLength"` with `"pinholeFocalLength"` in both the `validate_dict_elements` check and the dict lookup. Two-line key name correction, no other changes.

## Found via

Cross-parser comparison against the C++ reference implementation, which correctly reads `lens.pinholeFocalLength`.