### PR TITLE
Upstream pr/test mosys frame count contract

### DIFF
--- a/src/test/python/test_mosys_reader.py
+++ b/src/test/python/test_mosys_reader.py
@@ -21,6 +21,9 @@ class MoSysReaderTest(unittest.TestCase):
   def test_reader(self):
     clip = reader.to_clip("src/test/resources/mosys/A003_C001_01 15-03-47-01.f4", 20)
 
+    # Frame count contract: to_clip(f, n) must return exactly n frames (not n+1)
+    self.assertEqual(len(clip.sample_id), 20)
+
     # Test parameters against known values across multiple frames
     self.assertEqual(clip.protocol[0].name, OPENTRACKIO_PROTOCOL_NAME)
     self.assertEqual(clip.protocol[0].version, OPENTRACKIO_PROTOCOL_VERSION)


### PR DESCRIPTION
## Summary

Companion to #206. That PR fixes the off-by-one in `mosys/reader.py` (`count <= frames` → `count < frames`) but does not add a regression test. Without a test, the same class of error — or any future `<=` vs `<` mistake in the reader loop — will be invisible again.

This PR adds a single assertion to `test_mosys_reader.py` that locks the frame-count contract:

```python
# Frame count contract: to_clip(f, n) must return exactly n frames (not n+1)
self.assertEqual(len(clip.sample_id), 20)
```

Verified:
- Fails against the unfixed reader (`21 != 20`) — would have caught the bug
- Passes against the fixed reader

## Test plan

- [ ] Confirm this test fails on the unfixed reader (`count <= frames`)
- [ ] Confirm this test passes once #206 merges (`count < frames`)
