### PR TITLE
fix: guard pinhole focal length computation when no focal length axis is present

### DIFF
--- a/src/main/python/camdkit/mosys/f4.py
+++ b/src/main/python/camdkit/mosys/f4.py
@@ -284,8 +284,9 @@ class F4PacketParser:
       frame.transforms = ((transform,),)
       # Assuming a full frame 35mm active sensor 36x24mm
       # f = 36/[2*tand(FoV/2)]
-      fov_radians = fov_h * math.pi / 180.0
-      frame.lens_pinhole_focal_length = (36.0 / (2.0 * math.tan(fov_radians/2.0)),)
+      if fov_h != 0.0:
+        fov_radians = fov_h * math.pi / 180.0
+        frame.lens_pinhole_focal_length = (36.0 / (2.0 * math.tan(fov_radians/2.0)),)
       frame.lens_encoders = (FizEncoders(focus, iris, zoom),)
       frame.lens_distortions = ((Distortion(radial=(k1, k2),),),)
       frame.lens_projection_offset = (ProjectionOffset(cx, cy),)

--- a/src/test/python/test_mosys_reader.py
+++ b/src/test/python/test_mosys_reader.py
@@ -15,6 +15,7 @@ from camdkit.framework import (Vector3, Rotator3,
                                FizEncoders, Distortion, ProjectionOffset)
 from camdkit.model import OPENTRACKIO_PROTOCOL_NAME, OPENTRACKIO_PROTOCOL_VERSION
 from camdkit.mosys import reader
+from camdkit.mosys.f4 import F4PacketParser
 
 class MoSysReaderTest(unittest.TestCase):
   
@@ -43,3 +44,28 @@ class MoSysReaderTest(unittest.TestCase):
     self.assertEqual(clip.lens_projection_offset[13], ProjectionOffset(-7.783590793609619, 6.896144866943359))
     self.assertAlmostEqual(clip.lens_pinhole_focal_length[14], 22.35, 2)
     self.assertEqual(int(clip.lens_focus_distance[15]*1000), 2313)
+
+
+class MoSysF4ParserUnitTest(unittest.TestCase):
+
+  # Minimal valid F4 packet: timecode (25fps) + focus encoder — no focal length axis.
+  # Without the focal length axis, fov_h=0.0 and tan(0)=0 causes ZeroDivisionError.
+  # Checksum = (0x40 - sum(header+body)) % 256 = 0xae.
+  _PACKET_NO_FOCAL_LENGTH = bytes([
+    0xf4, 0x01, 0x02, 0x00,         # command, camera_id=1, axis_count=2, status=0
+    0xf8, 0x20, 0x00, 0x00, 0x00,   # timecode axis: 25fps, 00:00:00:00
+    0x03, 0x00, 0x00, 0x80, 0x00,   # focus encoder axis: 50%
+    0xae,                             # checksum
+  ])
+
+  def test_no_focal_length_axis_does_not_crash(self):
+    """get_tracking_frame() must not raise when no focal length axis is present.
+
+    fov_h defaults to 0.0. Without a guard, 36.0 / (2 * tan(0)) raises
+    ZeroDivisionError. The parser must skip pinhole focal length computation
+    and leave lens_pinhole_focal_length unset.
+    """
+    parser = F4PacketParser()
+    self.assertTrue(parser.initialise(self._PACKET_NO_FOCAL_LENGTH))
+    frame = parser.get_tracking_frame()
+    self.assertIsNone(frame.lens_pinhole_focal_length)


### PR DESCRIPTION
## Summary

`get_tracking_frame()` in `mosys/f4.py` unconditionally computes pinhole
focal length at the end of every frame using `fov_h`, which defaults to
`0.0` when no focal length axis (`0x53`) appears in the packet. The formula
`36.0 / (2.0 * math.tan(fov_radians / 2.0))` evaluates `tan(0) = 0`,
causing `ZeroDivisionError` and crashing the parser.

## Demonstration

BEFORE: `F4PacketParser.get_tracking_frame()` on any packet with no focal
  length axis raises `ZeroDivisionError: float division by zero`

AFTER:
  returns a valid frame with `lens_pinhole_focal_length` unset (`None`)

## Impact

Any F4 packet that omits the focal length axis (`FIELD_ID_FOCAL_LENGTH_FX`,
`0x53`) causes `get_tracking_frame()` to raise, aborting frame parsing.
Callers receive an unhandled exception rather than a partial frame.

## Change

`mosys/f4.py`: wrap the focal length computation in a `if fov_h != 0.0`
guard so it is only executed when a focal length axis was present in the
packet. Two-line change.

`test_mosys_reader.py`: add `test_no_focal_length_axis_does_not_crash` — a
unit test using a hand-crafted minimal packet with no focal length axis.
Verifies the parser returns a valid frame with `lens_pinhole_focal_length`
unset.

## Found via

Hypothesis-based property testing against a synthetic F4 packet generator.
Packets containing only the minimum required axes triggered the crash
immediately on the first generated example.
