### PR TITLE
fix: guard Synchronization construction when no timecode axis is present

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ pylint = "==2.6.0"
 coverage = "*"
 jsonschema = "*"
 jinja2 = "*"
+hypothesis = "*"
 
 [requires]
 python_version = "3.11"

--- a/correctness-plan.md
+++ b/correctness-plan.md
@@ -1,0 +1,239 @@
+# Correctness Plan
+
+The camdkit repo positions code and unit tests as the executable reference for the OpenTrackIO metadata model. Currently the tests are example- and unit-test-oriented. This plan adds property tests, metamorphic tests, a differential harness against an independent spec model, and a formal proof layer — building toward a credible verified conformance harness.
+
+**Architecture:**
+- Lean proofs define truth for the math
+- Python spec model defines executable truth for protocol semantics
+- camdkit is tested against both
+- Hypothesis searches the edge cases
+
+---
+
+## Step 1 — Property tests: generators and roundtrips
+
+Add Hypothesis to dev dependencies. Build generators for all model entities and establish the core JSON/schema invariants.
+
+### Core invariants
+
+```
+decode(encode(x)) ≡ canonicalize(x)
+encode(decode(json)) ≡ canonicalize(json)
+valid(x) → schema_accepts(to_json(x))
+schema_rejects(bad_json) → camdkit_rejects(bad_json)
+```
+
+The canonical form:
+
+```
+generated valid model
+  → to_json
+  → validate JSON schema
+  → from_json
+  → to_json
+  = canonical JSON
+```
+
+### Generators to build
+
+- Camera body (make, model, serial, firmware, label, ISO, shutter angle)
+- Lens (make, model, serial, firmware, nominal focal length, distortion objects, FIZ encoders)
+- Frame / timecode / PTP fields
+- Distortion objects (including multiple-object payloads)
+- Focus distance
+- Focal length / zoom
+- Sensor and image dimensions
+- Transforms and poses
+- Rational and StrictlyPositiveRational (all boundary conditions)
+- All constrained numeric types (int ranges, float constraints, normalized, unity-or-greater)
+
+### Boundary cases to encode as named Hypothesis examples from day one
+
+These come from open repo issues and changelog — they should be explicit boundary targets, not discovered later:
+
+- `focusDistance` = infinity, very large value, zero, missing
+- zoom lens `nominalFocalLength` undefined
+- vignetting payloads
+- multiple distortion objects in a single frame
+- PTP domain: 0, 127, 128, -1 (valid range is 0–127)
+
+### File layout
+
+```
+src/test/python/
+  property/
+    generators.py
+    test_json_roundtrip.py
+    test_schema_agreement.py
+```
+
+---
+
+## Step 2 — Metamorphic tests
+
+Metamorphic tests catch spec ambiguities that roundtrip tests miss. They assert relationships between inputs and outputs rather than exact values.
+
+### Properties
+
+**Structural neutrality:**
+- Adding irrelevant optional fields then canonicalizing does not change semantics
+- JSON key order does not affect decoded value
+- Missing optional field and explicit default agree where the spec says they should
+
+**Numeric normalization:**
+- Equivalent rational spellings normalize consistently (e.g. 2/4 vs 1/2 — spec says whether these are equal or distinct)
+- Unit conversion there-and-back is identity within tolerance
+
+**Geometric identity:**
+- Coordinate transform composed with identity is identity
+- Composing inverse transforms yields identity within floating-point tolerance
+
+**Lens/camera math:**
+```
+OpenCV params
+  → convert to OpenTrackIO / OpenLensIO
+  → project point
+  ≈ OpenCV project point
+```
+
+### Tolerance discipline
+
+Separate exact and floating properties from the start:
+
+- **Exact:** JSON structure, schema validity, discrete enum values, integer fields
+- **Floating:** projection and distortion transform results — use explicit tolerances, document the tolerance and why
+
+### File layout
+
+```
+src/test/python/
+  property/
+    test_metamorphic.py
+```
+
+---
+
+## Step 3 — Differential harness: independent spec model vs camdkit
+
+The differential oracle is an *independent* Python spec model written in plain dataclasses with no camdkit internals. This is the key design decision: `opentrackio_lib.py` (the existing reference parser in the repo) is camdkit-adjacent and may share the same misunderstandings. It can serve as a third comparator later, but not as the oracle.
+
+### Structure
+
+```
+src/test/python/
+  differential/
+    spec_model.py        # independent dataclasses + semantics, no camdkit imports
+    adapters.py          # spec ↔ camdkit conversion only
+    test_spec_vs_camdkit.py
+```
+
+### Differential flows
+
+**Forward:**
+```
+Hypothesis generated SpecValue
+  → spec_to_json
+  → camdkit.from_json
+  → camdkit.to_json
+  → spec_from_json
+  → compare semantic equality
+```
+
+**Reverse:**
+```
+Hypothesis generated camdkit-compatible JSON
+  → camdkit.from_json
+  → spec_from_json
+  → both accept and normalize same
+    OR both reject
+```
+
+### Most valuable differential properties
+
+| Property | Description |
+|---|---|
+| Acceptance agreement | `spec_accepts(x) ↔ camdkit_accepts(x)` |
+| Canonicalization agreement | `spec_canonical_json(x) = camdkit_canonical_json(x)` |
+| Lens math agreement | `spec_project(params, point) ≈ reference_project(params, point)` |
+| Conversion agreement | `spec_convert_opencv_to_opentrackio(params) ≈ camdkit/reference result` |
+
+Every disagreement is one of: implementation bug, spec ambiguity, missing precondition, or wrong test assumption. Treat all four as bugs worth filing.
+
+---
+
+## Step 4 — Projection and distortion differential tests
+
+Add OpenCV ↔ OpenTrackIO projection differential tests as a focused extension of Step 3. These require camera parameter generators that produce valid projection-testable configurations.
+
+```
+OpenCV params
+  → spec_convert_opencv_to_opentrackio
+  → spec_project(point)
+
+OpenCV params
+  → cv2.projectPoints(point)
+
+assert spec_result ≈ opencv_result within tolerance
+```
+
+Document tolerances and the exact pixel-coordinate convention assumptions (principal point origin, image plane orientation) as inline preconditions on each test — these are where subtle spec ambiguities will surface.
+
+---
+
+## Step 5 — Lean proof kernel
+
+Prove the semantic kernel; do not start by proving the full protocol.
+
+### Layers
+
+**Layer A — numeric and vector foundations**
+- Vec2, Vec3, matrices, affine transforms
+- Normalized coordinates
+- Pixel coordinates
+
+**Layer B — camera model semantics**
+- Pinhole projection
+- Principal point convention
+- Focal length convention
+- Sensor/image dimension assumptions
+
+**Layer C — distortion semantics**
+- Radial rational distortion
+- Tangential distortion
+- Denominator nonzero preconditions
+
+**Layer D — conversion theorems**
+- OpenCV params → OpenTrackIO params
+- Projection equivalence
+- Radial distortion equivalence
+- Full pixel equivalence under stated assumptions
+
+**Layer E — executable extraction**
+- Lean spec generates JSON test vectors
+- Python differential harness checks camdkit against them
+
+### Named theorems to prove
+
+- `principal_point_conversion_iff`
+- `focal_length_conversion_iff`
+- `linear_projection_pixel_equivalence`
+- `radial_distortion_value_equivalence`
+- `opencv_to_opentrackio_projection_equivalence`
+- `json_roundtrip_semantic_preservation`
+- `canonicalization_idempotent`
+
+### Design constraint
+
+Make theorem statements mirror the Hypothesis test properties. Every bug found by Hypothesis is then one of: implementation bug, spec ambiguity, missing precondition, or wrong theorem statement — a clear four-way triage instead of "the test failed."
+
+---
+
+## Sequence summary
+
+| Step | Deliverable |
+|---|---|
+| 1 | Hypothesis generators, roundtrip and schema agreement tests, boundary cases from open issues |
+| 2 | Metamorphic tests (key order, optional fields, numeric normalization, geometric identity) |
+| 3 | Independent Python spec model, adapters, differential acceptance and canonicalization tests |
+| 4 | OpenCV ↔ OpenTrackIO projection and distortion differential tests |
+| 5 | Lean proof kernel through Layer D, conformance vector export |

--- a/docs/arrows/README.md
+++ b/docs/arrows/README.md
@@ -1,0 +1,45 @@
+# Arrow Overlay
+
+This directory contains the arrow overlay for `ris-osvp-metadata-camdkit` — the navigation index and per-segment orientation pages for the Linked-Intent Development (LID) traceability chain.
+
+## What is an arrow?
+
+An arrow tracks the full intent chain for one domain cluster:
+
+```
+HLD → LLD → EARS specs → @spec annotations → tests → code
+```
+
+Each arrow has one orientation page (a `.md` file here) and one entry in `index.yaml`.
+
+## Segments
+
+| Arrow | Status | Summary |
+|---|---|---|
+| [protocol-envelope](protocol-envelope.md) | AUDITED | Clip model, schema machinery, primitive types |
+| [camera-identity](camera-identity.md) | AUDITED | Static hardware metadata — camera, lens, tracker |
+| [optical-characteristics](optical-characteristics.md) | AUDITED | Per-frame lens behavior — distortion, FIZ, Cooke |
+| [spatial-tracking](spatial-tracking.md) | AUDITED | 3D position/orientation, Mo-Sys F4 protocol |
+| [temporal-synchronization](temporal-synchronization.md) | AUDITED | Timecode, timestamps, PTP sync |
+| [format-bridge](format-bridge.md) | AUDITED | Proprietary camera format adapters |
+
+## How to use
+
+- **Find a segment**: check `index.yaml` for status and `next` action.
+- **Navigate to code**: each arrow doc's `## References` section links to the LLD, EARS spec file, test files, and source directories.
+- **Understand gaps**: `## Work Required` in each arrow doc lists must-fix, should-fix, and nice-to-have items.
+- **Check spec status**: `## Spec Coverage` tables show implemented vs. gap counts; full status is in `docs/specs/`.
+
+## Updating
+
+When making changes to a segment:
+1. Update the relevant `@spec` annotations in source code.
+2. Update the spec file (`docs/specs/{segment}-specs.md`) — change `[ ]` to `[x]` when closing a gap.
+3. Update the arrow doc's `## Spec Coverage` table and `## Work Required` section.
+4. Bump `audited` and `audited_sha` in `index.yaml` after verifying the change.
+
+Run `/arrow-maintenance` to audit all segments and regenerate derived views.
+
+## First audit
+
+All 6 segments were bootstrapped and audited on 2026-05-16 at git SHA `de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd`.

--- a/docs/arrows/camera-identity.md
+++ b/docs/arrows/camera-identity.md
@@ -1,0 +1,71 @@
+# Arrow: camera-identity
+
+Static hardware metadata describing the capture device — camera body, lens, and tracker make/model/serial.
+
+## Status
+
+**AUDITED** — last audited 2026-05-16 (git SHA `de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd`). Core type specs implemented; three reader gaps (Canon frame rate, Canon sensor dims, BMD multi-model sensor dims).
+
+## References
+
+### HLD
+- [docs/high-level-design.md](../high-level-design.md) — "Domain Clusters" row for Camera Identity
+
+### LLD
+- [docs/llds/camera-identity.md](../llds/camera-identity.md)
+
+### EARS
+- [docs/specs/camera-identity-specs.md](../specs/camera-identity-specs.md) — 16 specs (13 implemented, 3 gaps)
+
+### Tests
+- `src/test/python/test_camera_types.py`
+- `src/test/python/test_arri_reader.py`
+- `src/test/python/test_bmd_reader.py`
+- `src/test/python/test_canon_reader.py`
+- `src/test/python/test_red_reader.py`
+- `src/test/python/test_venice_reader.py`
+
+### Code
+- `src/main/python/camdkit/camera_types.py` (owned fully)
+- `src/main/python/camdkit/lens_types.py` → `StaticLens` only
+- `src/main/python/camdkit/tracker_types.py` → `StaticTracker` only
+
+## Architecture
+
+**Purpose:** Captures the static, hardware-level description of the capture device. Fields do not change frame-to-frame; they are set once per recording.
+
+**Key Components:**
+1. `StaticCamera` (`camera_types.py:59`) — camera body metadata; all fields optional; coerces rational fields before validation
+2. `PhysicalDimensions` (`camera_types.py:31`) — sensor area in mm (float h×w)
+3. `SenselDimensions` (`camera_types.py:44`) — photosite resolution in pixels (int h×w)
+4. `ShutterAngle` (`camera_types.py:56`) — constrained float [0.0, 360.0] degrees
+5. `StaticLens` (`lens_types.py:27`) — lens hardware identity; owned by Optical Characteristics file, referenced here
+6. `StaticTracker` (`tracker_types.py:19`) — tracker hardware identity; owned by Spatial Tracking file, referenced here
+
+## Spec Coverage
+
+| Category | Spec IDs | Implemented | Gaps |
+|---|---|---|---|
+| StaticCamera | CAMID-CAM-001 to CAMID-CAM-006 | 6 | 0 |
+| StaticLens | CAMID-LENS-001 to CAMID-LENS-004 | 4 | 0 |
+| StaticTracker | CAMID-TRK-001 | 1 | 0 |
+| Reader coverage | CAMID-READ-001 to CAMID-READ-008 | 5 | 3 |
+
+**Summary:** 16 of 16 type specs implemented; 3 reader gaps (CAMID-READ-006, CAMID-READ-007, CAMID-READ-008).
+
+## Key Findings
+
+1. **Generic Dimension[T] rejected** — two separate concrete classes (`PhysicalDimensions`, `SenselDimensions`) exist because a generic `Dimension[T]` pattern was incompatible with Pydantic v2 `Field` annotations. Documented comment at `camera_types.py:25`.
+2. **Sensor dimensions via pixel pitch lookup** — no camera protocol transmits physical sensor dimensions; all readers compute them from hardcoded lookup tables keyed on camera model string. ARRI supports 3 models, RED supports 6, BMD supports 1, Venice uses a hardcoded pitch, Canon is unsupported.
+3. **File boundary** — `StaticLens` and `StaticTracker` live in files owned by other clusters. This is a file-boundary issue only; no runtime coupling.
+4. **No tracker identity from readers** — no reader populates `StaticTracker` fields; tracker identity comes only from the Mo-Sys F4 protocol (Spatial Tracking cluster).
+
+## Work Required
+
+### Must Fix
+1. CAMID-READ-006: Canon `capture_frame_rate` not populated — investigate whether Duration/Timescale fields already parsed can yield frame rate
+2. CAMID-READ-007: Canon `active_sensor_physical_dimensions` not implemented
+3. CAMID-READ-008: BMD sensor dimensions limited to URSA Mini Pro 12K; all other BMD bodies produce no sensor dimension data
+
+### Nice to Have
+4. Extend ARRI and RED pixel pitch lookup tables as new camera models are released (no mechanism for extension without code change)

--- a/docs/arrows/format-bridge.md
+++ b/docs/arrows/format-bridge.md
@@ -1,0 +1,88 @@
+# Arrow: format-bridge
+
+Proprietary camera format adapters — ARRI AME CSV, Blackmagic RAW SDK text, Canon CSV, RED REDline CSV, and Sony Venice XML+CSV.
+
+## Status
+
+**AUDITED** — last audited 2026-05-16 (git SHA `de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd`). Two critical bugs in BMD reader; three entrance-pupil TODOs across ARRI, Venice, Canon; Canon missing frame rate and sensor dims.
+
+## References
+
+### HLD
+- [docs/high-level-design.md](../high-level-design.md) — "Domain Clusters" row for Format Bridge; "No shared error handling" cross-cutting concern
+
+### LLD
+- [docs/llds/format-bridge.md](../llds/format-bridge.md)
+
+### EARS
+- [docs/specs/format-bridge-specs.md](../specs/format-bridge-specs.md) — 25 specs (20 implemented, 5 gaps)
+
+### Tests
+- `src/test/python/test_arri_reader.py`
+- `src/test/python/test_bmd_reader.py`
+- `src/test/python/test_canon_reader.py`
+- `src/test/python/test_red_reader.py`
+- `src/test/python/test_venice_reader.py`
+
+### Test Resources
+- `src/test/resources/arri/B001C001_180327_R1ZA.mov.csv`
+- `src/test/resources/bmd/metadata.txt`
+- `src/test/resources/canon/20221007_TNumber_CanonCameraMetadata_{Static,Frames}.csv`
+- `src/test/resources/red/A001_C066_0303LZ_001.{static,frames}.csv`
+- `src/test/resources/venice/D001C005_210716AG{.csv,.xml}`
+
+### Code
+- `src/main/python/camdkit/arri/` (reader.py, cli.py)
+- `src/main/python/camdkit/bmd/` (reader.py, cli.py)
+- `src/main/python/camdkit/canon/` (reader.py, cli.py)
+- `src/main/python/camdkit/red/` (reader.py, cli.py)
+- `src/main/python/camdkit/venice/` (reader.py, cli.py)
+
+## Architecture
+
+**Purpose:** Converts proprietary camera metadata file formats into `Clip` objects via the shared `to_clip() -> Clip` interface. Each reader is an isolated adapter with no shared parsing code.
+
+**Key Components:**
+1. ARRI reader (`arri/reader.py:30`) — tab-delimited AME CSV; `t_number_from_linear_iris_value()` for T-stop conversion
+2. BMD reader (`bmd/reader.py:20`) — key:value text sections via regex; **two critical bugs**
+3. Canon reader (`canon/reader.py:19`) — 2 CSVs (static + frames); mode-dependent aperture; hex float focus decoding
+4. RED reader (`red/reader.py:26`) — 2 CSVs (meta_3 + meta_5); Cooke /i lens data; frame count validation
+5. Venice reader (`venice/reader.py:136`) — XML static + CSV frames; fractional T-stop string parsing; frame count validation
+
+## Spec Coverage
+
+| Category | Spec IDs | Implemented | Gaps |
+|---|---|---|---|
+| Shared interface | BRIDGE-IFACE-001 to BRIDGE-IFACE-002 | 2 | 0 |
+| ARRI | BRIDGE-ARRI-001 to BRIDGE-ARRI-005 | 3 | 2 |
+| BMD | BRIDGE-BMD-001 to BRIDGE-BMD-004 | 2 | 2 |
+| Canon | BRIDGE-CANON-001 to BRIDGE-CANON-004 | 4 | 0 |
+| RED | BRIDGE-RED-001 to BRIDGE-RED-003 | 3 | 0 |
+| Venice | BRIDGE-VENICE-001 to BRIDGE-VENICE-006 | 5 | 1 |
+
+**Summary:** 19 of 24 specs; 5 gaps (BRIDGE-ARRI-004,005; BRIDGE-BMD-003,004; BRIDGE-VENICE-006).
+
+## Key Findings
+
+1. **BMD `raise "string"` bug** — `bmd/reader.py:45`: `raise "Camera data does not contain frame information"` raises a string literal. In Python 3, `raise <non-exception>` is a `TypeError`. This reader crashes with the wrong exception type when input has no frame sections (BRIDGE-BMD-003).
+2. **BMD indentation bug** — `bmd/reader.py:112–123`: focal length, focus distance, and T-stop extraction are inside `if shutter_value is not None:`. These are silently dropped when shutter is absent (BRIDGE-BMD-004).
+3. **ARRI `assert` instead of `ValueError`** — `arri/reader.py:44`: `assert len_distance_unit == "Meter"` is stripped by Python's `-O` flag and produces `AssertionError` rather than a meaningful error (BRIDGE-ARRI-005).
+4. **Canon missing frame rate and sensor dims** — Canon reader explicitly comments out these fields (CAMID-READ-006, CAMID-READ-007); investigate whether derivation from existing fields is possible.
+5. **Inconsistent input type** — ARRI takes a path string; BMD/Canon/RED/Venice take file handles. Makes ARRI harder to unit test without filesystem.
+6. **Venice shutter ÷ 100 undocumented** — `venice/reader.py` divides shutter angle by 100 with no comment; the encoding (hundredths of a degree in XML) is not obvious.
+
+## Work Required
+
+### Must Fix
+1. BRIDGE-BMD-003: `raise "string"` → `raise ValueError(...)` at `bmd/reader.py:45`
+2. BRIDGE-BMD-004: Move focal length/focus/T-stop extraction out of `if shutter_value` block at `bmd/reader.py:112–123`
+3. BRIDGE-ARRI-005: `assert` → `if ... raise ValueError(...)` at `arri/reader.py:44`
+
+### Should Fix
+4. BRIDGE-ARRI-004: Wire up ARRI entrance pupil extraction (field exists in CSV, TODO in reader)
+5. BRIDGE-VENICE-006: Wire up Venice entrance pupil extraction (TODO at `venice/reader.py:200`)
+6. Add comment at Venice shutter angle division explaining the ÷100 encoding
+
+### Nice to Have
+7. Normalize reader input to file handles (align ARRI with others) for improved testability
+8. Add BMD sensor dimension support for camera models beyond URSA Mini Pro 12K

--- a/docs/arrows/index.yaml
+++ b/docs/arrows/index.yaml
@@ -1,0 +1,69 @@
+schema_version: 1
+last_updated: 2026-05-16
+
+arrows:
+  protocol-envelope:
+    status: AUDITED
+    sampled: 2026-05-16
+    audited: 2026-05-16
+    audited_sha: de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd
+    blocks: []
+    blockedBy: []
+    detail: protocol-envelope.md
+    next: "Fix f-string warning in versioning_types.py:31; fix __ALL__ typo in units.py:174; add PROTO-EX-005 (streaming example)"
+    drift: null
+
+  camera-identity:
+    status: AUDITED
+    sampled: 2026-05-16
+    audited: 2026-05-16
+    audited_sha: de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd
+    blocks: []
+    blockedBy: []
+    detail: camera-identity.md
+    next: "Investigate Canon frame rate derivation (CAMID-READ-006); implement Canon sensor dims (CAMID-READ-007); expand BMD pixel-pitch table beyond URSA Mini Pro 12K (CAMID-READ-008)"
+    drift: null
+
+  optical-characteristics:
+    status: AUDITED
+    sampled: 2026-05-16
+    audited: 2026-05-16
+    audited_sha: de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd
+    blocks: []
+    blockedBy: []
+    detail: optical-characteristics.md
+    next: "Fix BMD indentation bug (bmd/reader.py:112-123, OPT-LENS-003 regression); wire ARRI entrance pupil (OPT-LENS-004); wire Venice entrance pupil (OPT-LENS-005); add Cooke input validation (OPT-COOKE-004)"
+    drift: null
+
+  spatial-tracking:
+    status: AUDITED
+    sampled: 2026-05-16
+    audited: 2026-05-16
+    audited_sha: de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd
+    blocks: []
+    blockedBy: []
+    detail: spatial-tracking.md
+    next: "Remove dead import in transform_types.py:8; make F4 sensor size configurable (TRACK-F4-007); add GlobalPosition range validation (TRACK-F4-008)"
+    drift: null
+
+  temporal-synchronization:
+    status: AUDITED
+    sampled: 2026-05-16
+    audited: 2026-05-16
+    audited_sha: de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd
+    blocks: []
+    blockedBy: []
+    detail: temporal-synchronization.md
+    next: "Add lt=1_000_000_000 upper bound to Timestamp.nanoseconds (TSYNC-TS-002); tighten SynchronizationPTP.domain to [0,127]"
+    drift: null
+
+  format-bridge:
+    status: AUDITED
+    sampled: 2026-05-16
+    audited: 2026-05-16
+    audited_sha: de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd
+    blocks: []
+    blockedBy: []
+    detail: format-bridge.md
+    next: "Fix BMD raise-string bug (bmd/reader.py:45, BRIDGE-BMD-003); fix BMD indentation bug (bmd/reader.py:112-123, BRIDGE-BMD-004); fix ARRI assert (arri/reader.py:44, BRIDGE-ARRI-005)"
+    drift: null

--- a/docs/arrows/optical-characteristics.md
+++ b/docs/arrows/optical-characteristics.md
@@ -1,0 +1,75 @@
+# Arrow: optical-characteristics
+
+Per-frame lens behavior — distortion, focus/iris/zoom encoders, exposure falloff, geometric offsets, and the Cooke /i binary lens protocol.
+
+## Status
+
+**AUDITED** — last audited 2026-05-16 (git SHA `de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd`). All type specs implemented; 3 reader entrance-pupil gaps and 1 Cooke safety gap.
+
+## References
+
+### HLD
+- [docs/high-level-design.md](../high-level-design.md) — "Domain Clusters" row for Optical Characteristics
+
+### LLD
+- [docs/llds/optical-characteristics.md](../llds/optical-characteristics.md)
+
+### EARS
+- [docs/specs/optical-characteristics-specs.md](../specs/optical-characteristics-specs.md) — 17 specs (13 implemented, 4 gaps)
+
+### Tests
+- `src/test/python/test_lens_types.py`
+- `src/test/python/test_cooke_data.py`
+- `src/test/python/test_arri_reader.py` (t_number coverage)
+- `src/test/python/test_red_reader.py` (Cooke/entrance pupil coverage)
+- `src/test/python/property/test_json_roundtrip.py` (LensTypeRoundtripTests)
+
+### Code
+- `src/main/python/camdkit/lens_types.py` (dynamic classes owned here)
+- `src/main/python/camdkit/red/cooke.py`
+
+## Architecture
+
+**Purpose:** Models the per-frame optical state of the lens: its distortion profile, calibrated focus/iris/zoom positions, aperture, focal length, and the geometric offsets that relate the lens optical axis to the camera coordinate frame.
+
+**Key Components:**
+1. `Distortion` (`lens_types.py:88`) — Brown-Conrady distortion model with radial (≥1) and optional tangential coefficients; default model name `"Brown-Conrady D-U"`
+2. `FizEncoders` (`lens_types.py:133`) — normalized [0,1] focus/iris/zoom; at least one must be non-None
+3. `RawFizEncoders` (`lens_types.py:146`) — raw integer FIZ; at least one must be non-None
+4. `DistortionOffset` / `ProjectionOffset` (`lens_types.py:122,127`) — semantically distinct 2D planar offsets (both inherit `PlanarOffset`)
+5. `ExposureFalloff` (`lens_types.py:158`) — vignetting polynomial coefficients {a1, a2, a3}
+6. `lens_data_from_binary_string()` (`red/cooke.py:16`) — Cooke /i binary parser for entrance pupil and aperture
+
+## Spec Coverage
+
+| Category | Spec IDs | Implemented | Gaps |
+|---|---|---|---|
+| Distortion | OPT-DIST-001 to OPT-DIST-005 | 5 | 0 |
+| Encoders | OPT-ENC-001 to OPT-ENC-004 | 4 | 0 |
+| Offsets | OPT-OFFSET-001 | 1 | 0 |
+| Falloff | OPT-FALLOFF-001 | 1 | 0 |
+| Dynamic lens fields | OPT-LENS-001 to OPT-LENS-005 | 3 | 2 |
+| Cooke parser | OPT-COOKE-001 to OPT-COOKE-004 | 3 | 1 |
+
+**Summary:** 17 of 17 type specs implemented; 4 gaps (OPT-LENS-004, OPT-LENS-005 reader entrance-pupil TODOs; OPT-COOKE-004 safety validation).
+
+## Key Findings
+
+1. **BMD indentation bug** — `bmd/reader.py:112–123`: focal length, focus distance, and T-stop extraction are inside `if shutter_value is not None:` block. These values are silently dropped when the shutter metadata key is absent. This is a logic error, not a missing feature.
+2. **"At least one" constraint via `__init__` override** — both `FizEncoders` and `RawFizEncoders` enforce "at least one non-None field" in their `__init__` because Pydantic v2 has no native constraint for this pattern.
+3. **Cooke parser: no error handling** — `lens_data_from_binary_string()` (`red/cooke.py:16`) silently produces wrong values on short or malformed input (OPT-COOKE-004 gap).
+4. **T-stop sourcing varies by reader** — ARRI uses linear-to-T-stop lookup, BMD reads directly, Canon is mode-dependent (ApertureMode), RED uses Cooke aperture_value, Venice parses fractional stop strings.
+5. **`pinholeFocalLength` rename** — `Lens.focal_length` has JSON alias `pinholeFocalLength` (renamed in 1.0.0 to distinguish from `StaticLens.nominal_focal_length`).
+
+## Work Required
+
+### Must Fix
+1. BMD indentation bug at `bmd/reader.py:112–123` — focal length, focus, T-number silently dropped without shutter key
+
+### Should Fix
+2. OPT-LENS-004: ARRI entrance pupil — CSV field exists, parsing not wired up (`arri/reader.py` TODO)
+3. OPT-LENS-005: Venice entrance pupil — TODO at `venice/reader.py:200`
+4. OPT-COOKE-004: Add length validation to `lens_data_from_binary_string()` before bit extraction
+
+### Nice to Have
+5. Document `ExposureFalloff` {a1, a2, a3} polynomial model equation in LLD or spec file

--- a/docs/arrows/protocol-envelope.md
+++ b/docs/arrows/protocol-envelope.md
@@ -1,0 +1,88 @@
+# Arrow: protocol-envelope
+
+The structural core of camdkit — the `Clip` container, schema machinery, serialization, and primitive type foundation.
+
+## Status
+
+**AUDITED** — last audited 2026-05-16 (git SHA `de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd`). All active specs implemented except PROTO-EX-005 (deterministic UUID in examples).
+
+## References
+
+### HLD
+- [docs/high-level-design.md](../high-level-design.md) — "Domain Clusters", "Cross-Cutting Concerns", "Key Architectural Decisions"
+
+### LLD
+- [docs/llds/protocol-envelope.md](../llds/protocol-envelope.md)
+
+### EARS
+- [docs/specs/protocol-envelope-specs.md](../specs/protocol-envelope-specs.md) — 19 specs (18 implemented, 1 gap)
+
+### Tests
+- `src/test/python/test_clip.py`
+- `src/test/python/test_compatibility.py`
+- `src/test/python/test_model.py`
+- `src/test/python/test_numeric_types.py`
+- `src/test/python/test_string_types.py`
+- `src/test/python/test_utils.py`
+- `src/test/python/test_versioning_types.py`
+- `src/test/python/test_example_regression.py`
+- `src/test/python/property/test_json_roundtrip.py`
+- `src/test/python/property/test_schema_agreement.py`
+
+### Code
+- `src/main/python/camdkit/clip.py`
+- `src/main/python/camdkit/compatibility.py`
+- `src/main/python/camdkit/framework.py`
+- `src/main/python/camdkit/model.py`
+- `src/main/python/camdkit/versioning_types.py`
+- `src/main/python/camdkit/numeric_types.py`
+- `src/main/python/camdkit/string_types.py`
+- `src/main/python/camdkit/units.py`
+- `src/main/python/camdkit/utils.py`
+- `src/main/python/camdkit/examples.py`
+- `src/tools/python/generate_opentrackio_schema.py`
+- `src/tools/python/generate_component_schemas.py`
+
+## Architecture
+
+**Purpose:** Defines the `Clip` container for all OpenTrackIO metadata, synthesizes property accessors from JSON Schema metadata, generates and exports the OpenTrackIO JSON Schema, and provides the primitive type infrastructure shared by all domain clusters.
+
+**Key Components:**
+1. `Clip` (`clip.py`) — central model; metaprogramming-driven property synthesis via `setup_clip_properties()`; tuple-based multi-frame storage; `append()` / `__getitem__()` / `to_json()` operations
+2. `CompatibleBaseModel` (`compatibility.py`) — universal base class for all domain types; custom schema generation that strips Pydantic-internal wrapping layers
+3. `InternalCompatibleSchemaGenerator` / `ExternalCompatibleSchemaGenerator` — two-schema design; internal retains `clip_property` metadata, external strips it
+4. `VersionedProtocol` (`versioning_types.py`) — protocol name/version envelope; enforces `"OpenTrackIO"` name at construction
+5. `guess_fps()` (`utils.py`) — fuzzy float-to-rational FPS conversion for reader use
+6. Primitive types (`numeric_types.py`, `string_types.py`, `units.py`) — constrained primitives shared across all clusters
+7. `examples.py` — four canonical Clip fixtures for testing and documentation
+
+## Spec Coverage
+
+| Category | Spec IDs | Implemented | Gaps |
+|---|---|---|---|
+| Clip model | PROTO-CORE-001 to PROTO-CORE-010 | 10 | 0 |
+| Schema compatibility | PROTO-SCHEMA-001 to PROTO-SCHEMA-005 | 5 | 0 |
+| Examples | PROTO-EX-001 to PROTO-EX-005 | 4 | 1 |
+
+**Summary:** 19 of 20 active specs implemented; 1 gap (PROTO-EX-005).
+
+## Key Findings
+
+1. **Schema-driven metaprogramming** — `Clip.setup_clip_properties()` (`clip.py:213`) synthesizes all property accessors at class definition time from `json_schema_extra` `clip_property` paths. Adding a spec field requires only a Pydantic field declaration.
+2. **Two-schema design** — `InternalCompatibleSchemaGenerator` and `ExternalCompatibleSchemaGenerator` (`compatibility.py:256,260`) produce different outputs from the same model; the internal schema drives property synthesis, the external schema is the published spec.
+3. **Schema layer removal fragility** — `remove_layer()` in `compatibility.py` has a documented TODO at line 192 about `min_length`/`max_length` merging. This is a known fragility.
+4. **f-string bug** — `versioning_types.py:31`: `ValueError` message uses `{OPENTRACKIO_PROTOCOL_NAME}` in a plain string (not an f-string); error message prints literal braces rather than the value.
+5. **`__ALL__` typo** — `units.py`: `__ALL__` should be `__all__`; `from camdkit.units import *` will not export unit constants.
+6. **Non-deterministic examples** — `examples.py` calls `uuid4()` on every run; regression tests must normalize UUIDs for comparison (PROTO-EX-005 gap).
+
+## Work Required
+
+### Must Fix
+1. f-string bug in error message (`versioning_types.py:31`) — PROTO-CORE-007 (error message only, not the validation itself)
+2. `__ALL__` typo in `units.py` — cosmetic but breaks `import *`
+
+### Should Fix
+3. PROTO-EX-005 — deterministic UUID in examples for clean regression comparison
+
+### Nice to Have
+4. Document the `remove_layer()` fragility (TODO at `compatibility.py:192`) with a regression test before any schema surgery changes

--- a/docs/arrows/spatial-tracking.md
+++ b/docs/arrows/spatial-tracking.md
@@ -1,0 +1,76 @@
+# Arrow: spatial-tracking
+
+3D camera position and orientation — Transform types, Tracker dynamic state, GlobalPosition, and the Mo-Sys F4 binary tracking protocol.
+
+## Status
+
+**AUDITED** — last audited 2026-05-16 (git SHA `de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd`). Core F4 protocol implemented; 2 gaps (configurable sensor size, GlobalPosition range validation). Dead code in transform_types.py.
+
+## References
+
+### HLD
+- [docs/high-level-design.md](../high-level-design.md) — "Domain Clusters" row for Spatial Tracking; "Runtime Data Flow" diagram (MoSys path)
+
+### LLD
+- [docs/llds/spatial-tracking.md](../llds/spatial-tracking.md)
+
+### EARS
+- [docs/specs/spatial-tracking-specs.md](../specs/spatial-tracking-specs.md) — 13 specs (11 implemented, 2 gaps)
+
+### Tests
+- `src/test/python/test_transform_types.py`
+- `src/test/python/test_tracker_types.py`
+- `src/test/python/test_mosys_reader.py`
+- `src/test/python/property/test_json_roundtrip.py` (GeometricTypeRoundtripTests)
+
+### Code
+- `src/main/python/camdkit/transform_types.py`
+- `src/main/python/camdkit/tracker_types.py` (dynamic classes: `Tracker`, `GlobalPosition`)
+- `src/main/python/camdkit/mosys/f4.py`
+- `src/main/python/camdkit/mosys/reader.py`
+- `src/main/python/camdkit/mosys/cli.py`
+- Coordinate system reference: `src/main/resources/res/OpenCV_to_OpenTrackIO.pdf`
+
+## Architecture
+
+**Purpose:** Models where the camera is in 3D space per frame, and provides the Mo-Sys F4 binary protocol parser that is the primary live tracking data source in the codebase.
+
+**Key Components:**
+1. `Transform` (`transform_types.py:41`) — required translation (Vector3/meters) + rotation (Rotator3/degrees); optional scale and id; supports multiple named transforms per frame
+2. `Vector3` / `Rotator3` (`transform_types.py:17,29`) — nullable float components; units in meters/degrees
+3. `Tracker` (`tracker_types.py:43`) — per-frame notes, recording, slate, status tuples
+4. `GlobalPosition` (`tracker_types.py:65`) — ENU coordinates with geodetic anchor; no range validation
+5. `F4PacketParser.get_tracking_frame()` (`mosys/f4.py:194`) — decodes F4 binary packet into a single-frame Clip; dispatches on axis IDs via `match`/`case`
+6. `to_clip()` (`mosys/reader.py:21`) — accumulates frames via `Clip.append()`
+
+## Spec Coverage
+
+| Category | Spec IDs | Implemented | Gaps |
+|---|---|---|---|
+| Transform types | TRACK-TYPES-001 to TRACK-TYPES-005 | 5 | 0 |
+| Tracker dynamic state | TRACK-DYN-001 | 1 | 0 |
+| F4 protocol | TRACK-F4-001 to TRACK-F4-008 | 6 | 2 |
+
+**Summary:** 12 of 13 active specs implemented; 2 gaps (TRACK-F4-007 configurable sensor size, TRACK-F4-008 GlobalPosition range validation).
+
+## Key Findings
+
+1. **Hardcoded 36×24mm sensor** — `f4.py:287` assumes 35mm full-frame for focal length computation. Correct for many Mo-Sys rigs but wrong for others; no mechanism to configure per-rig (TRACK-F4-007 gap).
+2. **Dead import** — `transform_types.py:8`: `from multiprocessing.context import DefaultContext` is unused dead code.
+3. **Commented-out units in schema** — `Vector3` and `Rotator3` have units (`METER`, `DEGREE`) commented out of `json_schema_extra`. Reason not recorded; `Transform` fields do have units via field-level annotation.
+4. **Constructor/field type mismatch** — `Vector3`/`Rotator3` fields are `float | None` but constructors require non-None. `None` can only be set post-construction.
+5. **MoSys CLI outputs frame 0 only** — `mosys/cli.py` hardcodes reading 10 frames and printing only frame 0; not suitable as a general converter.
+6. **F4 parser requires Python 3.10+** — `get_tracking_frame()` uses `match`/`case`; Pipfile specifies Python 3.11 so this is not a constraint.
+
+## Work Required
+
+### Must Fix
+1. Remove unused import `from multiprocessing.context import DefaultContext` (`transform_types.py:8`)
+
+### Should Fix
+2. TRACK-F4-007: Make sensor size configurable in F4 parser rather than hardcoded 36×24mm
+3. TRACK-F4-008: Add range validation for `GlobalPosition.lat0` [−90, 90] and `lon0` [−180, 180]
+
+### Nice to Have
+4. Restore or explicitly delete commented-out units in `Vector3`/`Rotator3` `json_schema_extra`
+5. Align `mosys/cli.py` with other reader CLIs (full clip → stdout JSON)

--- a/docs/arrows/temporal-synchronization.md
+++ b/docs/arrows/temporal-synchronization.md
@@ -1,0 +1,69 @@
+# Arrow: temporal-synchronization
+
+Temporal metadata — SMPTE timecode, hardware timestamps, sync lock status, and IEEE 1588 PTP grandmaster clock configuration.
+
+## Status
+
+**AUDITED** — last audited 2026-05-16 (git SHA `de5c56e9b2bbecff1b7a89ca6ad0c6ea2cd04ebd`). All active specs implemented except TSYNC-TS-002 (nanoseconds upper bound missing).
+
+## References
+
+### HLD
+- [docs/high-level-design.md](../high-level-design.md) — "Domain Clusters" row for Temporal Synchronization
+
+### LLD
+- [docs/llds/temporal-synchronization.md](../llds/temporal-synchronization.md)
+
+### EARS
+- [docs/specs/temporal-synchronization-specs.md](../specs/temporal-synchronization-specs.md) — 16 specs (15 implemented, 1 gap)
+
+### Tests
+- `src/test/python/test_timing_types.py`
+- `src/test/python/test_mosys_reader.py` (timing data from F4)
+- `src/test/python/property/test_json_roundtrip.py` (TimingTypeRoundtripTests)
+
+### Code
+- `src/main/python/camdkit/timing_types.py` (all of it)
+
+## Architecture
+
+**Purpose:** Models when each sample was captured, including SMPTE timecode, hardware timestamps, and the full IEEE 1588 PTP grandmaster clock description required for broadcast-grade synchronization.
+
+**Key Components:**
+1. `Timecode` (`timing_types.py:65`) — SMPTE timecode with frame count validated against `frame_rate` ceiling
+2. `Timestamp` (`timing_types.py:95`) — 64-bit time as `seconds (uint48)` + `nanoseconds (uint32)`
+3. `SynchronizationPTP` (`timing_types.py:127`) — IEEE 1588 grandmaster clock: profile, domain, leader identity (MAC-pattern), priorities, accuracy, time source, mean path delay, VLAN
+4. `Synchronization` (`timing_types.py`) — per-frame sync status: locked, source, frequency, offsets, PTP config
+5. `Timing` (`timing_types.py:180`) — top-level per-frame timing container on `Clip`; `sample_rate` is the one non-tuple field
+
+## Spec Coverage
+
+| Category | Spec IDs | Implemented | Gaps |
+|---|---|---|---|
+| Timecode | TSYNC-TC-001 to TSYNC-TC-004 | 4 | 0 |
+| Timestamp | TSYNC-TS-001 to TSYNC-TS-002 | 1 | 1 |
+| PTP synchronization | TSYNC-PTP-001 to TSYNC-PTP-005 | 5 | 0 |
+| Synchronization | TSYNC-SYNC-001 to TSYNC-SYNC-003 | 3 | 0 |
+| Timing container | TSYNC-TIMING-001 to TSYNC-TIMING-003 | 3 | 0 |
+
+**Summary:** 16 of 16 specs; 1 gap (TSYNC-TS-002).
+
+## Key Findings
+
+1. **Only MoSys populates timing** — the five file-based readers (ARRI, BMD, Canon, RED, Venice) do not set any `Timing` fields. Static production files carry no live synchronization metadata.
+2. **`nanoseconds` missing upper bound** — `Timestamp.nanoseconds` is `NonNegativeInt` with no `lt=1_000_000_000` constraint; values ≥ 1 second are accepted as valid (TSYNC-TS-002 gap).
+3. **`domain` accepts 128–255** — `SynchronizationPTP.domain` is `NonNegative8BitInt` [0..255], but the spec and tests use [0..127]. Values 128–255 are accepted without error.
+4. **PTP_LEADER_PATTERN uses alternation** — Pydantic v2 does not support regex backreferences; the MAC-address pattern manually alternates `:` and `-` separators (`timing_types.py:32`).
+5. **`SynchronizationOffsets.__init__` signature mismatch** — all three params listed as required positional args but fields are `float | None`; inconsistency with the pattern used by other types.
+6. **`FrameRate` as subclass** — `FrameRate(StrictlyPositiveRational)` adds documentation metadata fields; it is not used as a field type anywhere in the model. Unusual pattern that conflates value type with documentation carrier.
+
+## Work Required
+
+### Must Fix
+1. TSYNC-TS-002: Add `lt=1_000_000_000` constraint to `Timestamp.nanoseconds`
+
+### Should Fix
+2. Tighten `SynchronizationPTP.domain` to `[0, 127]` to match spec intent (currently [0, 255])
+
+### Nice to Have
+3. Evaluate `FrameRate` subclass pattern — if it is never used as a runtime field type, consider replacing with a plain constants dict

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -1,0 +1,204 @@
+# camdkit — High-Level Design
+
+## System Purpose
+
+camdkit is a Python library that defines the canonical **OpenTrackIO metadata model** for broadcast camera tracking. It provides: (1) a schema-driven `Clip` container that holds all camera, lens, tracker, and timing metadata for a recording; (2) adapters that convert proprietary camera file formats into `Clip` objects; (3) the authoritative JSON Schema for the OpenTrackIO wire format; and (4) reference documentation and example data. It is the reference implementation of the SMPTE RIS OSVP camera metadata specification.
+
+## Architecture Overview
+
+The system has two orthogonal structures: a **dependency hierarchy** (what imports what) and a **data flow** (how data moves through the system at runtime).
+
+### Dependency Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Format Bridge                    Spatial Tracking (MoSys)  │
+│  ARRI │ BMD │ Canon │ RED │Venice  F4 binary protocol       │
+└──────────────────────┬────────────────────┬─────────────────┘
+                       │  to_clip() → Clip  │
+                       ▼                    ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Protocol Envelope — Clip                                   │
+│  Schema-driven property synthesis · Serialization           │
+│  Public API (framework.py, model.py)                        │
+└──────┬──────────────┬───────────────┬──────────────┬────────┘
+       │              │               │              │
+       ▼              ▼               ▼              ▼
+┌──────────┐  ┌──────────────┐  ┌──────────┐  ┌──────────────┐
+│ Camera   │  │ Optical      │  │ Temporal │  │ Spatial      │
+│ Identity │  │ Charact.     │  │ Sync     │  │ Tracking     │
+│          │  │              │  │          │  │ (types only) │
+└──────────┘  └──────────────┘  └──────────┘  └──────────────┘
+       │              │               │              │
+       └──────────────┴───────────────┴──────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Protocol Envelope — Foundation                             │
+│  CompatibleBaseModel · numeric_types · string_types         │
+│  units · utils                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Runtime Data Flow
+
+```
+Proprietary files                    Live binary stream
+(ARRI CSV, BMD text,                 (Mo-Sys F4 packets)
+ Canon CSV, RED CSV,                        │
+ Venice XML+CSV)                            │ F4PacketParser
+       │                                    │ .get_tracking_frame()
+       │ reader.to_clip()                   │
+       ▼                                    ▼
+       ┌────────────────────────────────────┐
+       │             Clip                   │
+       │  static.*   (singleton fields)     │
+       │  dynamic.*  (tuple[T, ...] fields) │
+       │                                    │
+       │  .append(frame_clip) ──────────────┤ ← MoSys accumulation
+       │  clip[i] ──────────────────────────┤ ← frame extraction
+       └──────────────┬─────────────────────┘
+                      │
+          ┌───────────┴────────────────┐
+          ▼                            ▼
+  clip.to_json()              Clip.make_json_schema()
+  OpenTrackIO JSON            JSON Schema document
+  (wire format)               (published spec)
+          │
+          └──────────────────────────────┐
+                                         ▼
+                               examples.py → reference JSON
+                               make_opentrackio_documentation.py
+                               → HTML documentation site
+```
+
+## Domain Clusters
+
+| Cluster | What it answers | Key types |
+|---|---|---|
+| **Protocol Envelope** | How is metadata structured and transmitted? | `Clip`, `CompatibleBaseModel`, `VersionedProtocol`, schema generators |
+| **Camera Identity** | What device captured this? | `StaticCamera`, `StaticLens`, `StaticTracker` |
+| **Optical Characteristics** | How does the lens behave per frame? | `Lens`, `Distortion`, `FizEncoders`, `ExposureFalloff` |
+| **Spatial Tracking** | Where is the camera in 3D space? | `Transform`, `Vector3`, `Rotator3`, `Tracker`, `GlobalPosition` |
+| **Temporal Synchronization** | When exactly did each sample occur? | `Timing`, `Timecode`, `Timestamp`, `Synchronization`, `SynchronizationPTP` |
+| **Format Bridge** | How do proprietary formats map to `Clip`? | ARRI, BMD, Canon, RED, Venice readers |
+
+## Cross-Cutting Concerns
+
+### CompatibleBaseModel — universal base
+
+Every domain type in the codebase inherits from `CompatibleBaseModel` rather than Pydantic's `BaseModel` directly. This provides uniform serialization behavior (`to_json`/`from_json`), consistent validation config (`validate_assignment=True`, `extra='forbid'`), and the custom JSON Schema generator that strips Pydantic's internal wrapping layers.
+
+### json_schema_extra — connective tissue
+
+All field definitions carry metadata in `json_schema_extra`:
+
+```python
+Field(..., json_schema_extra={
+    "clip_property": ("static", "camera", "capture_frame_rate"),
+    "units": HERTZ,
+    "constraints": STRICTLY_POSITIVE_RATIONAL,
+    "sampling": "static",
+    "section": "camera",
+})
+```
+
+This metadata drives three separate mechanisms: property accessor synthesis (via `clip_property` path), JSON Schema export (units, constraints, section), and documentation generation (all fields). It is the connective tissue that makes the schema-driven design work.
+
+### Tuple semantics for dynamic data
+
+Every per-frame field is `tuple[T, ...]`, never a list. This is enforced consistently across all domain type clusters. The tuple is the unit of per-frame data; `Clip.append()` concatenates tuples; `clip[i]` slices them. Lists are never stored; when Pydantic receives a list input for a tuple field, it coerces it.
+
+### Positional `__init__` constructors
+
+All domain type classes override Pydantic v2's keyword-only `__init__` to accept positional arguments. This is a cross-cutting camdkit 0.9 API compatibility constraint. Every `CompatibleBaseModel` subclass follows this pattern.
+
+### guess_fps() for frame rate normalization
+
+Camera metadata sources express frame rate as floating-point approximations (23.976, 29.97). `guess_fps()` converts these to exact rationals (24000/1001, 30000/1001) via fuzzy matching within 1%. Used by the ARRI and RED readers; should be used by any future reader that parses a floating-point frame rate.
+
+### No shared error handling
+
+The six readers use inconsistent error strategies:
+- ARRI: `assert` (produces `AssertionError`, stripped by `-O`)
+- RED, Venice: `raise ValueError(...)`
+- BMD: `raise "string"` (produces `TypeError` — a bug)
+- Canon, most: silent omission (unsupported fields simply not set)
+
+There is no cross-cutting error handling pattern. Failures surface inconsistently to callers.
+
+### No logging
+
+No logging infrastructure exists anywhere in the library. Reader errors are either raised as exceptions or silently dropped. There is no way for a caller to distinguish "field not in source format" from "field parsing failed."
+
+## Key Architectural Decisions
+
+| Decision | What was chosen | Why it matters |
+|---|---|---|
+| **Schema-driven metaprogramming** | `Clip.setup_clip_properties()` synthesizes property accessors from `json_schema_extra` at class definition time | Adding a spec field requires only a Pydantic field declaration; no accessor code. The schema and the API stay in sync by construction |
+| **Pydantic v2 rewrite** | Full rewrite in 1.0.0 (7,461 lines added) | Replaced bespoke validation with an industry-standard framework; enabled the two-schema design and `json_schema_extra` metadata pattern |
+| **Two-schema design** | `InternalCompatibleSchemaGenerator` (retains `clip_property`) vs `ExternalCompatibleSchemaGenerator` (strips it) | Property synthesis machinery is invisible in the published schema; internal and external representations are cleanly separated |
+| **Static + dynamic in one Clip** | `Clip.Static` (singletons) + tuple fields (per-frame) in one class | Consumers always receive one object; no type branching; append semantics are explicit |
+| **No abstract reader base class** | Five standalone adapter modules | Zero shared parsing code between readers; an abstraction would be empty; the contract is enforced by tests |
+| **Pixel pitch lookup tables** | Hardcoded per-reader maps for sensor dimension computation | Camera protocols do not transmit physical sensor dimensions; lookup tables are the only practical approach without manufacturer APIs |
+| **Cooke /i for RED optical data** | `red/cooke.py` parses Cooke binary protocol for entrance pupil + T-stop | Cooke /i is the only file-based source of calibrated entrance pupil position and lens-side T-stop in the codebase |
+
+## Shared Infrastructure
+
+| Infrastructure | Details |
+|---|---|
+| **Pydantic v2** | Validation, serialization, JSON Schema generation for all domain types |
+| **jsonref** | Inlines `$ref` pointers in the generated schema, producing a self-contained document |
+| **hypothesis** | Property-based test generation for JSON roundtrip and schema agreement tests |
+| **jsonschema** | Validates generated Clip JSON against the published schema in property tests |
+| **jinja2** | Renders the OpenTrackIO HTML documentation from a template |
+| **Test resources** | Real camera output files in `src/test/resources/` (ARRI, BMD, Canon, MoSys, RED, Venice) — one corpus file per reader |
+
+No databases, message queues, caches, or network services are used at runtime. camdkit is a pure in-process library.
+
+## Known Technical Debt (Cross-Cluster)
+
+| Issue | Location | Severity |
+|---|---|---|
+| `raise "string"` bug | `bmd/reader.py:45` | High — crashes with wrong exception type |
+| Indentation bug | `bmd/reader.py:112–123` | High — T-stop/focus silently dropped when no shutter key |
+| `assert` instead of `ValueError` | `arri/reader.py:44` | Medium — stripped by `-O`, wrong error type |
+| f-string bug in error message | `versioning_types.py:31` | Low — error message prints literal text instead of value |
+| `__ALL__` typo | `units.py` | Low — `import *` won't export unit constants |
+| Unused import | `transform_types.py:8` | Low — `DefaultContext` import is dead code |
+| Commented-out units in schema | `transform_types.py:22,34` | Low — unclear if intentional omission |
+| Hardcoded 36×24mm sensor | `mosys/f4.py:287` | Medium — wrong for non-35mm rigs |
+| `nanoseconds` no upper bound | `timing_types.py` | Medium — accepts values > 999,999,999 |
+| `domain` allows 128–255 | `timing_types.py` | Low — out-of-spec for most PTP profiles |
+
+## Non-Goals
+
+camdkit explicitly does **not**:
+- Transmit data over a network (no UDP, TCP, WebSocket, or NMOS)
+- Decode or process video frames
+- Perform real-time tracking or IMU sensor fusion
+- Calibrate camera or lens systems
+- Control camera hardware
+- Solve tracking (no bundle adjustment, no SLAM)
+- Provide a storage format or database
+- Support tracking data from systems other than Mo-Sys F4 (live) and the five supported camera file formats (file-based)
+
+## Correctness Roadmap
+
+`correctness-plan.md` defines a five-step path toward formal verification:
+
+| Step | Status | Description |
+|---|---|---|
+| 1 | ✅ Complete | Hypothesis property tests: JSON roundtrip + schema agreement |
+| 2 | Upcoming | Metamorphic tests (key order, numeric normalization, geometric identity) |
+| 3 | Planned | Independent Python spec model + differential testing against camdkit |
+| 4 | Planned | OpenCV↔OpenTrackIO projection differential tests |
+| 5 | Long-term | Lean proof kernel through Layer D |
+
+## References
+
+- LLDs: `docs/llds/` (6 cluster-level design documents)
+- Coordinate system derivation: `src/main/resources/res/OpenCV_to_OpenTrackIO.pdf`
+- OpenLensIO lens spec: `src/main/resources/res/OpenLensIO_v1-0-1.pdf`
+- Correctness roadmap: `correctness-plan.md`
+- Release history: `CHANGELOG.md`

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -190,7 +190,7 @@ camdkit explicitly does **not**:
 | Step | Status | Description |
 |---|---|---|
 | 1 | ✅ Complete | Hypothesis property tests: JSON roundtrip + schema agreement |
-| 2 | Upcoming | Metamorphic tests (key order, numeric normalization, geometric identity) |
+| 2 | ✅ Complete | Metamorphic tests (key order, numeric normalization, geometric identity) |
 | 3 | Planned | Independent Python spec model + differential testing against camdkit |
 | 4 | Planned | OpenCV↔OpenTrackIO projection differential tests |
 | 5 | Long-term | Lean proof kernel through Layer D |

--- a/docs/llds/camera-identity.md
+++ b/docs/llds/camera-identity.md
@@ -1,0 +1,138 @@
+# Camera Identity
+
+## Context and Design Philosophy
+
+Camera Identity captures the static, hardware-level description of the capture device: who made it, what model it is, what sensor it has, what lens is attached, and what tracker is recording its position. These fields describe facts that do not change frame-to-frame — they are set once for a recording and stay constant.
+
+The cluster spans three Pydantic models — `StaticCamera`, `StaticLens`, and `StaticTracker` — which map to the `clip.static.camera`, `clip.static.lens`, and `clip.static.tracker` sub-objects in the serialized `Clip`. All fields are optional in the schema; there is no required minimum set of device metadata.
+
+**File boundary note:** `StaticCamera` lives in `camera_types.py` (owned entirely by this cluster). `StaticLens` lives in `lens_types.py` and `StaticTracker` lives in `tracker_types.py` — both files are owned by the Optical Characteristics and Spatial Tracking clusters respectively, because those files contain predominantly dynamic types. Camera Identity references the static sub-classes across that boundary.
+
+## StaticCamera
+
+`StaticCamera` (`camera_types.py`) is the primary hardware descriptor for the camera body.
+
+### Fields
+
+| Field | Type | Units | Notes |
+|---|---|---|---|
+| `make` | `NonBlankUTF8String` | — | Manufacturer name |
+| `model` | `NonBlankUTF8String` | — | Camera model name |
+| `serial_number` | `NonBlankUTF8String` | — | Body serial number |
+| `firmware_version` | `NonBlankUTF8String` | — | Firmware version string |
+| `label` | `NonBlankUTF8String` | — | User-assigned label (e.g. "A-cam") |
+| `capture_frame_rate` | `StrictlyPositiveRational` | Hz | Frames per second as exact rational |
+| `active_sensor_physical_dimensions` | `PhysicalDimensions` | mm | Active sensor area height × width |
+| `active_sensor_resolution` | `SenselDimensions` | pixel | Active sensor photosites height × width |
+| `iso` | `StrictlyPositiveInt` | — | ISO sensitivity |
+| `fdl_link` | `UUIDURN` | — | UUID URN referencing an ASC FDL file |
+| `shutter_angle` | `ShutterAngle` | degree | Shutter angle [0.0, 360.0] |
+| `anamorphic_squeeze` | `StrictlyPositiveRational` | — | Horizontal squeeze factor (1.0 = spherical) |
+
+All fields are optional. The `@field_validator` on `capture_frame_rate` and `anamorphic_squeeze` auto-coerces inputs to `StrictlyPositiveRational` before validation, accepting ints, `Rational` objects, or `{"num": n, "denom": d}` dicts.
+
+### Dimension types
+
+Two separate dimension types exist rather than a generic `Dimension[T]`:
+
+- `PhysicalDimensions` — `height: float`, `width: float`, both ≥ 0, in millimeters. Represents the physical size of the active sensor area.
+- `SenselDimensions` — `height: int`, `width: int`, both in `[0, MAX_INT_32]`, in pixels. Represents the photosite resolution.
+
+Both override Pydantic's `__init__` to accept positional arguments (camdkit 0.9 legacy, consistent with all other domain types).
+
+### ShutterAngle
+
+`ShutterAngle` is a type alias (`Annotated[float, Field(ge=0.0, le=360.0)]`) rather than a class. It appears as a field on `StaticCamera` — stored as a static value in the `Clip`. Some camera readers (ARRI, RED, BMD, Canon, Venice) populate `shutter_angle` from per-clip metadata even though individual frames could in principle have different shutter angles. There is no per-frame shutter angle field in the current model.
+
+## StaticLens
+
+`StaticLens` (in `lens_types.py`) captures the optical hardware identity of the attached lens.
+
+### Fields
+
+| Field | Type | Units | Notes |
+|---|---|---|---|
+| `make` | `NonBlankUTF8String` | — | Lens manufacturer |
+| `model` | `NonBlankUTF8String` | — | Lens model name |
+| `serial_number` | `NonBlankUTF8String` | — | Lens serial number |
+| `firmware_version` | `NonBlankUTF8String` | — | Lens firmware |
+| `nominal_focal_length` | `StrictlyPositiveInt` | mm | Marked focal length of lens |
+| `calibration_history` | `tuple[NonBlankUTF8String, ...]` | — | Ordered list of calibration event descriptions |
+| `overscan_percent` | `UnityOrGreaterFloat` | — | Minimum overscan factor required by this lens (≥ 1.0) |
+
+`nominal_focal_length` is the prime or zoom label on the lens body (e.g. 50mm), distinct from the computed `pinhole_focal_length` in per-frame optical data. `calibration_history` is unbounded in length; individual strings are capped at 1023 chars.
+
+## StaticTracker
+
+`StaticTracker` (in `tracker_types.py`) captures the hardware identity of the tracking device.
+
+### Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `make` | `NonBlankUTF8String` | Tracker manufacturer |
+| `model` | `NonBlankUTF8String` | Tracker model |
+| `serial_number` | `NonBlankUTF8String` | Tracker serial number |
+| `firmware_version` | `NonBlankUTF8String` | Tracker firmware |
+
+All fields are optional strings with 1–1023 char constraint.
+
+## How Readers Populate Camera Identity
+
+All six readers set camera identity fields from their proprietary source format:
+
+| Field | ARRI | BMD | Canon | MoSys | RED | Venice |
+|---|---|---|---|---|---|---|
+| `camera_make` | CSV | "Blackmagic" | "Canon" | — | CSV | XML |
+| `camera_model` | CSV | CSV | — | — | CSV | XML |
+| `camera_serial_number` | CSV | CSV | — | — | CSV ("PIN") | XML |
+| `camera_firmware` | — | CSV | — | — | CSV | XML |
+| `lens_make` | — | — | — | — | CSV | XML |
+| `lens_model` | — | CSV | — | — | CSV | XML |
+| `lens_serial_number` | — | — | — | — | CSV | XML (✓) |
+| `lens_nominal_focal_length` | CSV | CSV | CSV | — | CSV | CSV |
+| `capture_frame_rate` | CSV | CSV | ⚠ unsupported | F4 packet | CSV | XML |
+| `active_sensor_physical_dimensions` | computed (pixel pitch map) | computed (hardcoded) | ⚠ unsupported | assumed 36×24mm | computed (pixel pitch map) | computed (pixel pitch × resolution) |
+
+**Sensor dimension strategy:** No reader receives physical dimensions directly from the camera. Instead, readers compute sensor dimensions from a combination of pixel pitch (a hardware constant per sensor model) and resolution:
+- ARRI and RED: `_CAMERA_FAMILY_PIXEL_PITCH_MAP` / `_LENS_NAME_PIXEL_PITCH_MAP` — lookup tables keyed on camera/sensor model string.
+- BMD: hardcoded only for "Blackmagic URSA Mini Pro 12K".
+- Venice: hardcoded pixel pitch (22800/3840 µm per pixel), scaled by resolution.
+- MoSys: hardcoded assumption of 35mm full-frame (36×24mm) in `f4.py`.
+- Canon: not implemented (comment at reader line 53).
+
+## Decisions & Alternatives
+
+| Decision | Chosen | Alternatives Considered | Rationale |
+|---|---|---|---|
+| Static device metadata as nested sub-objects | `Clip.Static.camera`, `Clip.Static.lens`, `Clip.Static.tracker` | Flat fields on `Clip` | [inferred] Groups related fields; mirrors the spec document structure; reduces top-level Clip field count |
+| Generic `Dimension[T]` | Rejected — two separate classes (`PhysicalDimensions`, `SenselDimensions`) | `Dimension[float]` / `Dimension[int]` | Explicit: Pydantic v2 `Field` annotation incompatibility with generic type parameters (documented comment at `camera_types.py:25`) |
+| `shutter_angle` as static, not per-frame | Field on `StaticCamera` | Per-frame tuple field | [inferred] Most camera sources provide a single shutter angle per clip; per-frame shutter is not in the spec |
+| Pixel pitch lookup tables per reader | Hardcoded maps keyed on camera model string | Receive physical dims from camera, or user-supplied | [inferred] Camera manufacturer protocols do not expose physical sensor dimensions directly; lookup tables are the only practical approach |
+| All static fields optional | No required fields on `StaticCamera`, `StaticLens`, `StaticTracker` | Require make+model minimum | [inferred] Different readers support different subsets; a required minimum would make many real clips invalid |
+| Positional `__init__` constructors | Override Pydantic's keyword-only default | Keyword-only | Explicit: camdkit 0.9 API compatibility |
+
+## Open Questions & Future Decisions
+
+### Resolved
+1. ✅ Whether to keep static device metadata separate from dynamic per-frame data — yes, `Clip.Static` nesting established in 1.0.0 rewrite
+
+### Deferred
+1. ARRI, RED, and Venice sensor dimension lookup tables are hardcoded per camera/sensor model. When new camera bodies are released, these tables require manual updates. No mechanism exists to extend them without a code change.
+2. BMD reader only supports "Blackmagic URSA Mini Pro 12K" for sensor dimension computation. All other BMD bodies will produce a `Clip` with no `active_sensor_physical_dimensions`.
+3. MoSys F4 reader assumes 35mm full-frame (36×24mm) regardless of actual camera body. This is hardcoded in `f4.py:287`.
+4. Canon reader does not populate `capture_frame_rate` or `active_sensor_physical_dimensions` (comments at `canon/reader.py:53`).
+5. No tracker identity fields (make, model, serial) are populated by any reader other than implicitly through MoSys F4 protocol data.
+6. `StaticLens` and `StaticTracker` live in `lens_types.py` and `tracker_types.py` respectively — files primarily owned by Optical Characteristics and Spatial Tracking. This is a file-boundary awkwardness only; no runtime coupling issue.
+
+## References
+
+- Files owned by this cluster:
+  - `src/main/python/camdkit/camera_types.py` (all of it)
+- Files cross-referenced (static sub-classes only):
+  - `src/main/python/camdkit/lens_types.py` → `StaticLens`
+  - `src/main/python/camdkit/tracker_types.py` → `StaticTracker`
+- Dependencies on other clusters:
+  - Protocol Envelope: `CompatibleBaseModel`, `NonBlankUTF8String`, `UUIDURN`, `StrictlyPositiveRational`, `StrictlyPositiveInt`, `UnityOrGreaterFloat`, `units`
+- Populated by: all six Format Bridge readers (ARRI, BMD, Canon, MoSys, RED, Venice)
+- External dependencies: `pydantic`, `fractions`

--- a/docs/llds/format-bridge.md
+++ b/docs/llds/format-bridge.md
@@ -1,0 +1,254 @@
+# Format Bridge
+
+## Context and Design Philosophy
+
+Format Bridge covers the five camera-manufacturer readers that convert proprietary metadata formats into `Clip` objects: ARRI, Blackmagic Design (BMD), Canon, RED, and Sony Venice. The Mo-Sys reader is in the Spatial Tracking cluster because it decodes a live-streaming binary wire protocol rather than a production file format.
+
+Each reader is an isolated adapter — they share no code with each other, only the `Clip` contract they produce. The design philosophy is one adapter per format: no abstraction layer, no base class, no shared parsing infrastructure. Each reader knows exactly what its source format looks like and maps it directly to `Clip` fields.
+
+The shared interface contract is:
+
+```python
+to_clip(*file_args) -> Clip
+```
+
+And the shared CLI pattern is:
+
+```python
+def main():
+    # argparse to collect file paths
+    clip = reader.to_clip(path_or_handle)
+    print(json.dumps(clip.to_json(), indent=2))
+```
+
+## Reader Format Overview
+
+| Reader | Input | Parser | Static source | Per-frame source |
+|---|---|---|---|---|
+| **ARRI** | 1 tab-delimited CSV (AME export) | `csv` module | First CSV row | All rows |
+| **BMD** | 1 text file (key: value sections) | `re` regex | "Clip Metadata" section | "Frame N Metadata" sections |
+| **Canon** | 2 CSVs (static + frames) | `csv` module | `static_csv` (1 row) | `frames_csv` (N rows) |
+| **RED** | 2 CSVs (meta_3 + meta_5, REDline output) | `csv` module | `meta_3_file` (1 row) | `meta_5_file` (N rows) |
+| **Venice** | XML (static) + CSV (per-frame) | `xml.etree` + `csv` | XML document | CSV rows |
+
+## ARRI Reader
+
+**Input:** Tab-delimited CSV exported by ARRI Meta Extract (AME) from an Alexa clip.
+
+**Key CSV fields used:**
+
+| CSV field | Clip field |
+|---|---|
+| `Exposure Index ASA` | `iso` |
+| `Project FPS` | `capture_frame_rate` (via `guess_fps()`) |
+| `Camera Model` | `camera_model` |
+| `Camera Serial Number` | `camera_serial_number` |
+| `Lens Model` | `lens_model` |
+| `Lens Focal Length` | `lens_nominal_focal_length` |
+| `Lens Focus Distance` | `lens_focus_distance` (per-frame tuple) |
+| `Lens Linear Iris` | `lens_t_number` (per-frame, via `t_number_from_linear_iris_value()`) |
+| `Shutter Angle` | `shutter_angle` |
+
+Sensor dimensions are computed from `_CAMERA_FAMILY_PIXEL_PITCH_MAP`, a hardcoded lookup table for three ALEXA LF variants. Camera models not in the map produce no sensor dimension data.
+
+`t_number_from_linear_iris_value(lin_value)` converts a raw linear iris integer from the CSV to an approximate T-stop using a threshold-based comparison against standard T-stop values. It is exported and independently tested.
+
+**Known issues:**
+- Line 44: `assert len_distance_unit == "Meter"` — crashes with `AssertionError` on non-meter CSV files instead of raising a meaningful `ValueError`.
+- Entrance pupil position is not extracted (TODO comment in reader).
+- No `camera_make` field — ARRI cameras always have make "ARRI" but the reader does not set it explicitly.
+
+## BMD Reader
+
+**Input:** Text file produced by the Blackmagic RAW SDK `ExtractMetadata` tool. Structure:
+
+```
+Clip Metadata
+  key: value
+  ...
+Frame 0 Metadata
+  key: value
+  ...
+Frame 1 Metadata
+  ...
+```
+
+Three compiled regex patterns parse the sections: `_CLIP_HEADING_RE`, `_FRAME_HEADING_RE`, `_METADATA_LINE_RE`.
+
+**Key metadata keys used:**
+
+| Text key | Clip field |
+|---|---|
+| `Camera Make` | `camera_make` |
+| `Camera Model` | `camera_model` |
+| `Camera Serial Number` | `camera_serial_number` |
+| `Camera Firmware` | `camera_firmware` |
+| `Lens Model` | `lens_model` |
+| `ISO` | `iso` |
+| `Frame Rate` | `capture_frame_rate` |
+| `Shutter Angle` | `shutter_angle` |
+| `Anamorphic Squeezed` | `anamorphic_squeeze` |
+| `Focal Length` | `lens_nominal_focal_length` (if constant) |
+| `Focus Distance` | `lens_focus_distance` (per-frame) |
+| `T-Stop` | `lens_t_number` (per-frame) |
+
+Sensor dimensions are hardcoded for `"Blackmagic URSA Mini Pro 12K"` only. All other BMD bodies produce no sensor dimension data.
+
+**Critical bugs:**
+1. **Line 45:** `raise "Camera data does not contain frame information"` — raises a string literal rather than an exception. In Python 3, `raise <non-exception>` is a `TypeError` at runtime. This reader cannot handle clips with no frame sections without crashing with the wrong error type.
+2. **Lines 112–123:** Focal length, focus distance, and T-stop extraction are indented inside the `if shutter_value is not None:` block. These values are only extracted when the shutter metadata key is present. A clip with focus/T-stop data but no shutter key silently drops those values.
+3. White balance extraction is fully commented out (lines 102+). No replacement.
+
+## Canon Reader
+
+**Input:** Two CSVs exported by the Canon camera:
+- `static_csv` — one row of clip-level metadata
+- `frames_csv` — one row per frame
+
+**Key fields:**
+
+| CSV key | Clip field | Notes |
+|---|---|---|
+| `Duration` / `Timescale` | `duration` | Rational duration |
+| `LensSqueezeFactor` | `anamorphic_squeeze` | Enum: 0→1.0, 1→1.33, 2→2.0, 3→1.8 |
+| `PhotographicSensitivity` | `iso` | Adjusted by offset 0x80000000 when mode==1 |
+| `ExposureTime` | `shutter_angle` | — |
+| `FocalLength` | `lens_nominal_focal_length` | From frames CSV |
+| `FocusPosition` | `lens_focus_distance` | Hex-encoded float32, decoded via `struct.unpack` |
+| `ApertureNumber` | `lens_t_number` or `lens_f_number` | Mode-dependent: ApertureMode==2→t, ==1→f |
+
+`_read_float32_as_hex()` decodes Canon's hex-encoded float32 focus position values.
+
+The anamorphic squeeze enum mapping (0→1.0, 1→1.33, 2→2.0, 3→1.8) is hardcoded; 1.8x is Canon's proprietary anamorphic format.
+
+**Unsupported fields:** `capture_frame_rate`, `active_sensor_physical_dimensions`, `entrance_pupil_offset` (all noted with comments in reader).
+
+**`camera_make` is hardcoded to `"Canon"`.**
+
+## RED Reader
+
+**Input:** Two CSVs produced by the REDline CLI tool:
+- `meta_3_file` — static metadata (1 row, `--useMeta 3` flag)
+- `meta_5_file` — per-frame metadata (N rows, `--useMeta 5` flag)
+
+**Key fields:**
+
+| CSV key | Clip field | Notes |
+|---|---|---|
+| `ISO` | `iso` | — |
+| `Camera Model` | `camera_model` | — |
+| `Camera PIN` | `camera_serial_number` | PIN = Product Identification Number |
+| `Firmware Version` | `camera_firmware` | — |
+| `Lens Brand` | `lens_make` | — |
+| `Lens Name` | `lens_model` | — |
+| `Lens Serial Number` | `lens_serial_number` | — |
+| `FPS` | `capture_frame_rate` | Via `guess_fps()` |
+| `Pixel Aspect Ratio` | `anamorphic_squeeze` | — |
+| `Shutter (deg)` | `shutter_angle` | — |
+| `Focal Length` | `lens_nominal_focal_length` | From frames CSV |
+| `Focus Distance` | `lens_focus_distance` | Per-frame |
+| `Cooke Metadata` | `lens_entrance_pupil_offset`, `lens_t_number` | Hex-encoded binary, parsed via `red/cooke.py` |
+
+Sensor dimensions are computed from `_LENS_NAME_PIXEL_PITCH_MAP` keyed on the `Sensor Name` field. Six variants are supported: RAPTOR, MONSTRO, KOMODO, HELIUM, GEMINI, DRAGON.
+
+**Frame count validation:** raises `ValueError` if `meta_3["Total Frames"]` != `len(meta_5_rows)`. This is the only reader that validates data consistency between its two input files.
+
+Cooke `/i` metadata is the richest optical source of any file-based reader: it provides both entrance pupil position and calibrated T-stop directly from the lens.
+
+## Venice Reader
+
+**Input:** XML static file + CSV per-frame file from a Sony Venice camera.
+
+The XML uses the namespace `urn:schemas-professionalDisc:nonRealTimeMeta:ver.2.10`. Helper functions extract specific elements:
+
+| Helper | Extracts |
+|---|---|
+| `find_camera_info()` | manufacturer, modelName, serialNo, firmware (from Element[@hardware='Main-Board']) |
+| `find_lens_info()` | lens modelName, serialNo |
+| `find_fps()` | captureFps attribute from VideoFrame element |
+| `find_duration()` | Duration element |
+| `find_px_dims()` | numOfVerticalLine, pixel from VideoLayout |
+| `find_value(name)` | Named Item[@name] elements for ISO, ShutterSpeedAngle, PixelAspectRatio |
+
+**Per-frame CSV fields:** `Focal Length (mm)`, `Focus Distance (ft)`, `Aperture`.
+
+**Notable transformations:**
+- `shutter_angle`: XML stores in 100ths of a degree; divided by 100 in reader. No comment explains this.
+- `focus_distance`: CSV is in feet; converted to meters via `12 * 25.4 / 1000` (12 inches/foot × 25.4mm/inch ÷ 1000 mm/m).
+- `lens_t_number`: parsed from strings like `"T 2"`, `"T 2.8"`, `"T 2 3/10"` via `t_number_from_frac_stop()`, computed as `2^(aperture/2)`.
+- Sensor dimensions: hardcoded pixel pitch `22800/3840` µm per pixel, scaled by resolution.
+- `anamorphic_squeeze`: parsed from a ratio string (e.g., `"2:1"` → 2.0).
+
+**Frame count validation:** raises `ValueError` if XML duration != CSV row count.
+
+## Feature Coverage Matrix
+
+| Field | ARRI | BMD | Canon | RED | Venice |
+|---|---|---|---|---|---|
+| `camera_make` | — | ✓ | "Canon" (hardcoded) | ✓ | ✓ |
+| `camera_model` | ✓ | ✓ | — | ✓ | ✓ |
+| `camera_serial_number` | ✓ | ✓ | — | ✓ | ✓ |
+| `camera_firmware` | — | ✓ | — | ✓ | ✓ |
+| `capture_frame_rate` | ✓ | ✓ | ⚠ unsupported | ✓ | ✓ |
+| `active_sensor_physical_dimensions` | ✓ (3 models) | ✓ (1 model) | ⚠ unsupported | ✓ (6 sensors) | ✓ |
+| `iso` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `shutter_angle` | ✓ | ✓ | ✓ | ✓ | ✓ (÷100) |
+| `anamorphic_squeeze` | ✓ | ✓ | ✓ (enum) | ✓ | ✓ |
+| `lens_make` | — | — | — | ✓ | ✓ |
+| `lens_model` | ✓ | ✓ | — | ✓ | ✓ |
+| `lens_serial_number` | — | — | — | ✓ | ✓ |
+| `lens_firmware` | — | — | — | ✓ | — |
+| `lens_nominal_focal_length` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `lens_focus_distance` | ✓ | ✓ ⚠ bug | ✓ (hex float) | ✓ | ✓ (ft→m) |
+| `lens_t_number` | ✓ (linear→T) | ✓ ⚠ bug | ✓ (mode 2) | ✓ (Cooke) | ✓ (frac stop) |
+| `lens_f_number` | — | — | ✓ (mode 1) | — | — |
+| `lens_entrance_pupil_offset` | ⚠ TODO | — | ⚠ unsupported | ✓ (Cooke) | ⚠ TODO |
+
+## Decisions & Alternatives
+
+| Decision | Chosen | Alternatives Considered | Rationale |
+|---|---|---|---|
+| No shared reader base class | Each reader is a standalone module | Abstract base class with `to_clip()` protocol | [inferred] Five readers, zero shared parsing code — an abstraction would be empty; the contract is enforced by tests, not inheritance |
+| File handle vs path string as input | Mixed: ARRI/MoSys take path strings; BMD/Canon/RED/Venice take file handles | Uniform path strings or uniform file handles | [inferred] Inconsistency reflects independent authorship; file handles are more testable (no filesystem dependency in tests) |
+| Pixel pitch lookup tables per reader | Hardcoded maps in each reader module | Central shared lookup table | [inferred] Lookup tables are camera-make-specific; no cross-reader sharing is needed; keeping them local avoids coupling |
+| Frame count validation (RED, Venice) | Raise `ValueError` if frame counts disagree | Silently truncate to shorter | [inferred] Mismatched frame counts indicate corrupted or mismatched input files; fail-fast is correct |
+| `guess_fps()` for frame rate parsing | Fuzzy match to known frame rates via 1% threshold | Parse exact rational from string | [inferred] Camera CSV exports often contain floating-point FPS approximations (e.g., 23.976) that need to map to exact rationals (24000/1001) |
+| Canon anamorphic squeeze as enum | Map {0→1.0, 1→1.33, 2→2.0, 3→1.8} | Read raw value | Explicit: Canon encodes squeeze as a 4-value enum; 1.8x is Canon's proprietary format |
+| Venice shutter angle ÷ 100 | Divide raw XML value by 100 | Store raw value | [inferred] Venice XML encodes shutter angle in hundredths of a degree; no comment in code explains this |
+
+## Open Questions & Future Decisions
+
+### Resolved
+1. ✅ Mo-Sys assigned to Spatial Tracking cluster rather than Format Bridge (it decodes a live wire protocol, not a production file)
+
+### Deferred
+1. **BMD `raise "string"` bug** (`bmd/reader.py:45`): must be changed to `raise ValueError("...")`. Currently crashes with `TypeError` at runtime when no frame sections are found.
+2. **BMD indentation bug** (`bmd/reader.py:112–123`): focal length, focus distance, and T-stop only extracted inside `if shutter_value is not None:` block. Fix requires un-indenting these lines.
+3. **ARRI `assert` at line 44**: `assert len_distance_unit == "Meter"` should be `if len_distance_unit != "Meter": raise ValueError(...)`. `assert` is removed by Python's `-O` optimization flag and produces `AssertionError` instead of a meaningful message.
+4. **ARRI entrance pupil position**: CSV contains the field; reader has a TODO but does not extract it.
+5. **Venice entrance pupil offset**: TODO comment at `venice/reader.py:200`. Field is present in some Venice metadata.
+6. **Canon `capture_frame_rate` and `active_sensor_physical_dimensions`**: marked unsupported in comments. The Canon CSV format may not contain frame rate; investigate whether it can be derived from `Duration` / `Timescale` fields already being parsed.
+7. **BMD sensor dimensions**: only "Blackmagic URSA Mini Pro 12K" is supported. URSA Mini Pro G2, URSA Mini 4.6K, Pocket Cinema Camera 6K, etc. would produce clips with no sensor dimensions.
+8. **Input interface inconsistency**: ARRI takes a path string; BMD/Canon/RED/Venice take file handles. Normalizing to file handles would improve testability of ARRI; normalizing to paths would simplify CLI code. Either direction is acceptable but should be consistent.
+9. **Venice shutter angle ÷ 100**: a comment explaining the encoding (XML stores as 100ths of a degree) should be added at `venice/reader.py` near the division.
+10. **White balance (BMD)**: the extraction is fully commented out. Determine if white balance is in the OpenTrackIO spec; if so, restore; if not, remove the dead comment.
+
+## References
+
+- Files owned by this cluster:
+  - `src/main/python/camdkit/arri/reader.py`, `arri/cli.py`, `arri/__init__.py`
+  - `src/main/python/camdkit/bmd/reader.py`, `bmd/cli.py`, `bmd/__init__.py`
+  - `src/main/python/camdkit/canon/reader.py`, `canon/cli.py`, `canon/__init__.py`
+  - `src/main/python/camdkit/red/reader.py`, `red/cli.py`, `red/__init__.py`
+  - `src/main/python/camdkit/venice/reader.py`, `venice/cli.py`, `venice/__init__.py`
+- Dependencies on other clusters:
+  - Protocol Envelope: `Clip`, `guess_fps()`, `utils`
+  - Camera Identity: `StaticCamera`, `StaticLens`, `StaticTracker` (all populated here)
+  - Optical Characteristics: `Lens`, `Distortion`, `FizEncoders`, `DistortionOffset` (populated by readers); `red/cooke.py` (owned by Optical Characteristics, consumed here)
+- Test resources:
+  - `src/test/resources/arri/B001C001_180327_R1ZA.mov.csv`
+  - `src/test/resources/bmd/metadata.txt`
+  - `src/test/resources/canon/20221007_TNumber_CanonCameraMetadata_{Static,Frames}.csv`
+  - `src/test/resources/red/A001_C066_0303LZ_001.{static,frames}.csv`
+  - `src/test/resources/venice/D001C005_210716AG{,.csv,.xml}`
+- External dependencies: `csv`, `re`, `xml.etree.ElementTree`, `struct`, `fractions`, `math`

--- a/docs/llds/optical-characteristics.md
+++ b/docs/llds/optical-characteristics.md
@@ -1,0 +1,145 @@
+# Optical Characteristics
+
+## Context and Design Philosophy
+
+Optical Characteristics covers the per-frame state of the lens: its distortion profile, focus and iris positions (both normalized and raw), exposure falloff, focal length, and the geometric offsets that relate the lens's optical axis to the camera's coordinate frame.
+
+These are dynamic fields — one value per sample — stored as tuples in `Clip`. They are the primary data consumed by VFX compositing and virtual production pipelines to project CGI into the real camera's optical model.
+
+The cluster is anchored in `lens_types.py`, which owns all dynamic lens Pydantic models. `StaticLens` (hardware identity) also lives in this file but is logically owned by the Camera Identity cluster.
+
+## Dynamic Lens Fields on Clip
+
+The `Lens` class (`lens_types.py`) is the per-frame container. All fields are optional; a `Clip` may populate any subset.
+
+| Field | Type | Units | Notes |
+|---|---|---|---|
+| `distortions` | `tuple[Distortion, ...]` (≥ 1) | — | One or more distortion models for this frame |
+| `distortion_offset` | `DistortionOffset` | — | 2D offset of distortion center from image center |
+| `projection_offset` | `ProjectionOffset` | — | 2D offset of projection center from image center |
+| `encoders` | `FizEncoders` | normalized [0,1] | Focus / iris / zoom encoder readings |
+| `raw_encoders` | `RawFizEncoders` | integer | Raw (uncalibrated) FIZ encoder readings |
+| `f_number` | `StrictlyPositiveFloat` | — | Aperture as f-stop |
+| `t_number` | `StrictlyPositiveFloat` | — | Aperture as T-stop (calibrated) |
+| `focal_length` | `StrictlyPositiveFloat` | mm | Pinhole focal length (computed, not the marked label) |
+| `focus_distance` | `StrictlyPositiveFloat` | m | Focus distance |
+| `entrance_pupil_offset` | `StrictlyPositiveFloat` | m | Nodal point offset from origin |
+| `exposure_falloff` | `ExposureFalloff` | — | Vignetting coefficients {a1, a2, a3} |
+| `custom` | `NonBlankUTF8String` | — | Vendor-specific extension payload |
+
+### Focal length naming
+
+`focal_length` on `Lens` is the **computed pinhole equivalent focal length** — it changes per-frame as zoom/focus breathe. It was renamed from `focal_length` to `pinhole_focal_length` in the 1.0.0 release (CHANGELOG). The current field name in the Pydantic model is `focal_length` with JSON alias `pinholeFocalLength`. This is distinct from `StaticLens.nominal_focal_length`, which is the marked prime/zoom label.
+
+## Distortion Model
+
+`Distortion` represents a single lens distortion model.
+
+```
+Distortion:
+  model: str                        # default "Brown-Conrady D-U"
+  radial: tuple[float, ...]         # min_length=1; Brown-Conrady k1..kN coefficients
+  tangential: tuple[float, ...] | None   # p1, p2 tangential coefficients
+  overscan: float (≥ 1.0) | None    # minimum overscan required by this distortion
+```
+
+`distortions` on `Lens` is `tuple[Distortion, ...]` — a frame can carry more than one distortion model simultaneously (e.g., when both a Brown-Conrady and a custom model are valid for the same frame). The tuple must have at least one entry.
+
+`Distortion.check_tuples_not_empty()` is a model validator that explicitly rejects empty `radial` tuples. This is redundant with `min_length=1` on the `Field`, but is explicit belt-and-suspenders.
+
+## Encoder Types
+
+### FizEncoders (normalized)
+
+Normalized focus/iris/zoom in `[0.0, 1.0]`. All three fields are optional; at least one must be present at construction time. The "at least one" constraint is enforced in a custom `__init__` override because Pydantic v2 has no built-in constraint for "at least one of these optional fields must be non-None."
+
+### RawFizEncoders (integer)
+
+Uncalibrated raw encoder counts as integers. Same "at least one" constraint, same custom `__init__` enforcement pattern.
+
+Both encoder types use camelCase JSON aliases (`focusPosition`, `irisPosition`, `zoomPosition`).
+
+## Geometric Offsets
+
+Two planar offset types exist, both inheriting from `PlanarOffset` (`{x: float, y: float}`):
+
+- `DistortionOffset` — offset of the distortion center from the image center
+- `ProjectionOffset` — offset of the projection (principal point) from the image center
+
+The two subclasses are structurally identical — no additional fields or validators. The distinction is purely semantic: they describe different optical phenomena that happen to both be 2D offsets.
+
+## Exposure Falloff
+
+`ExposureFalloff` holds three vignetting polynomial coefficients: `a1`, `a2`, `a3`. These model the radial light falloff from the lens center. No model equation is documented in the code; the field names and interpretation are defined by the OpenTrackIO spec.
+
+## Cooke Lens Protocol (RED reader)
+
+`red/cooke.py` parses Cooke `/i` lens metadata embedded in RED camera files. This is the only reader that provides entrance pupil position and uses a calibrated aperture value from the lens itself rather than the camera body.
+
+Two dataclasses:
+- `CookeLensData` — `entrance_pupil_position` (signed, 14-bit), `aperture_value` (12-bit, unsigned)
+- `CookeFixedData` — `firmware_version_number` (string at bytes 61–65)
+
+Extraction is pure bitwise arithmetic against hardcoded byte and bit offsets from the Cooke `/i` format specification. No validation or error handling — malformed data produces wrong values silently.
+
+`entrance_pupil_position` sign is encoded as bit 5 of byte 25; magnitude spans bits 0–9 across bytes 25–26. `aperture_value` is 12 bits across bytes 5–6.
+
+## Reader Coverage for Optical Data
+
+| Field | ARRI | BMD | Canon | MoSys | RED | Venice |
+|---|---|---|---|---|---|---|
+| `t_number` | ✓ (from linear iris) | ✓ | ✓ (aperture mode 2) | — | ✓ (Cooke) | ✓ (fractional stop string) |
+| `f_number` | — | — | ✓ (aperture mode 1) | ✓ | — | — |
+| `focus_distance` | ✓ (m) | ✓ | ✓ (hex float) | ✓ | ✓ | ✓ (ft→mm→m) |
+| `encoders` (normalized FIZ) | — | — | — | ✓ | — | — |
+| `distortions` | — | — | — | ✓ | — | — |
+| `projection_offset` | — | — | — | ✓ | — | — |
+| `entrance_pupil_offset` | ⚠ TODO | — | ⚠ unsupported | ✓ (F4 field 0x3E) | ✓ (Cooke) | ⚠ TODO |
+| `focal_length` (pinhole) | — | — | — | ✓ | — | — |
+
+### T-stop / f-stop sourcing strategies per reader
+
+- **ARRI** — `t_number_from_linear_iris_value()`: converts a linear iris integer from the CSV using a lookup against standard T-stop values. The function is exported and independently tested.
+- **BMD** — T-stop read directly from "T-Stop" key in the metadata text; focus and focal length extraction has an indentation bug (lines 112–123 are inside the `if shutter_value is not None:` block, meaning they're only extracted when shutter data is present).
+- **Canon** — Mode-dependent: `ApertureMode == 2` → `t_number`, `ApertureMode == 1` → `f_number`. Focus distance decoded from a float32 hex string using `struct.unpack`.
+- **MoSys** — F4 binary field IDs: `0x2E` (f-number), `0x2F` (focus distance), `0x3E` (entrance pupil), `0x3C` (focal length), plus FIZ encoder axes by axis ID.
+- **RED** — T-stop from Cooke `aperture_value` (12-bit), scaled. Focus distance from "Focus Distance" CSV column.
+- **Venice** — T-stop parsed from strings like `"T 2"`, `"T 2.8"`, `"T 2 3/10"` via regex; computed as `2^(aperture/2)`. Focus distance converted from feet to mm.
+
+## Decisions & Alternatives
+
+| Decision | Chosen | Alternatives Considered | Rationale |
+|---|---|---|---|
+| `distortions` as tuple (multiple models per frame) | `tuple[Distortion, ...]` with min_length=1 | Single `Distortion` field | [inferred] Some workflows need to carry multiple calibrated distortion models simultaneously (e.g., for different downstream pipelines) |
+| Separate `DistortionOffset` and `ProjectionOffset` subclasses | Two semantically distinct classes, both subclass `PlanarOffset` | Single `PlanarOffset` type used for both | [inferred] Future-proofing — the two offsets may diverge (add metadata fields); semantic distinction aids documentation generation |
+| Normalized vs raw encoders as separate fields | `FizEncoders` (normalized) and `RawFizEncoders` (raw integer) | Single encoder type with a flag | [inferred] Both are useful: normalized for interop, raw for round-tripping to the original device |
+| "At least one" FIZ field enforced in `__init__` | Custom `__init__` override | Pydantic `model_validator` | [inferred] Pydantic v2 has no native "at least one optional field must be present" constraint; `__init__` override is the clearest expression |
+| Cooke data parsed in `red/cooke.py` separately | Standalone module `CookeLensData` + `CookeFixedData` dataclasses | Inline in `red/reader.py` | [inferred] Cooke `/i` is a published third-party protocol; separating it allows independent testing and potential reuse by other readers |
+| `focal_length` → `pinholeFocalLength` JSON alias | Renamed in 1.0.0 | Keep `focalLength` | Explicit: CHANGELOG notes semantic clarification — "pinhole" distinguishes computed from marked focal length |
+| `ExposureFalloff` as {a1, a2, a3} | Three named coefficients | Array of N coefficients | [inferred] Fixed-degree polynomial is sufficient for typical vignetting; named fields are clearer in schema documentation |
+
+## Open Questions & Future Decisions
+
+### Resolved
+1. ✅ `focal_length` renamed to `pinholeFocalLength` in 1.0.0 to distinguish from `nominal_focal_length`
+
+### Deferred
+1. ARRI reader: entrance pupil position not implemented (TODO comment in `arri/reader.py`). ARRI CSV contains the field; parsing is just not wired up.
+2. Venice reader: entrance pupil offset not implemented (TODO at `venice/reader.py:200`).
+3. Canon reader: entrance pupil offset explicitly marked unsupported (comment at `canon/reader.py:72`).
+4. BMD reader: indentation error at lines 112–123 causes focal length, focus position, and T-number extraction to only occur when shutter data is present. This is a logic bug, not a missing feature.
+5. Cooke parser (`red/cooke.py`): no validation or error handling — malformed input produces wrong values silently. Binary offsets are hardcoded with no reference to which version of the Cooke `/i` spec they target.
+6. `ExposureFalloff` coefficients `{a1, a2, a3}` — the polynomial model and normalization conventions are not documented in code; defer to spec document for interpretation.
+7. `PlanarOffset` base class with two identical subclasses: if `DistortionOffset` and `ProjectionOffset` never diverge structurally, the inheritance hierarchy adds complexity for no gain. Evaluate at next major schema revision.
+
+## References
+
+- Files owned by this cluster:
+  - `src/main/python/camdkit/lens_types.py` (dynamic classes: `Distortion`, `Distortions`, `PlanarOffset`, `DistortionOffset`, `ProjectionOffset`, `FizEncoders`, `RawFizEncoders`, `ExposureFalloff`, `Lens`)
+  - `src/main/python/camdkit/red/cooke.py`
+- Files cross-referenced (static sub-class only):
+  - `src/main/python/camdkit/lens_types.py` → `StaticLens` (owned by Camera Identity)
+- Dependencies on other clusters:
+  - Protocol Envelope: `CompatibleBaseModel`, `NonBlankUTF8String`, `StrictlyPositiveFloat`, `NormalizedFloat`, `NonNegativeInt`, `UnityOrGreaterFloat`, `NonNegativeFloat`, `units`
+- Populated by: ARRI reader (T-stop, focus), BMD reader (T-stop, focus), Canon reader (T/f-stop, focus), MoSys reader (FIZ encoders, distortion, projection offset, focal length, f-number), RED reader (T-stop + Cooke entrance pupil), Venice reader (T-stop, focus)
+- External dependencies: `pydantic`, `dataclasses`, `struct` (Canon reader)

--- a/docs/llds/protocol-envelope.md
+++ b/docs/llds/protocol-envelope.md
@@ -1,0 +1,154 @@
+# Protocol Envelope
+
+## Context and Design Philosophy
+
+The Protocol Envelope is the structural center of camdkit. It defines the `Clip` — the canonical container for all OpenTrackIO metadata — and the infrastructure that governs how that container is validated, serialized, and published as a JSON Schema.
+
+The guiding principle is **schema-driven design**: the shape of `Clip`, its properties, their units, sampling modes, and documentation are all declared once in Pydantic field metadata (`json_schema_extra`), and everything downstream — property accessors, JSON serialization, schema export, documentation generation — is derived from that declaration. No hand-coding of accessors; no parallel data structures.
+
+A second principle is **compatibility-first schema export**: the JSON Schema emitted to consumers strips Pydantic's internal layers (defaults, anyOf-for-None, title fields) to produce a clean, spec-aligned document that matches the OpenTrackIO 0.9 / 1.x specification format.
+
+## The Clip Model
+
+`Clip` (`src/main/python/camdkit/clip.py`) is the central data model. It holds all metadata for a recorded clip or a stream of tracking frames.
+
+### Static vs. dynamic fields
+
+Fields are divided into two kinds:
+
+- **Static** — singleton values that describe the recording as a whole (camera make, sensor size, protocol version). Stored directly on `Clip` or on `Clip.Static` sub-objects.
+- **Dynamic** — per-frame tuples (one entry per sample). Examples: `lens_t_number`, `timing_timecode`, `transforms`. Stored as `tuple[T, ...]` fields.
+
+This tuple-based design allows a single `Clip` object to represent either a single frame (tuple of length 1) or a complete multi-frame recording (tuple of length N), without a separate container class.
+
+### Metaprogramming-driven accessors
+
+`Clip` does not hand-code its property accessors. Instead, `Clip.setup_clip_properties()` (called at class definition time, line 315) traverses the Pydantic JSON schema via `Clip.traverse_json_schema()` and synthesizes `@property` accessors on the fly using `setattr()`.
+
+Each synthesized property is backed by a `clip_property` entry in a field's `json_schema_extra` — a `tuple[str, ...]` path that describes where the property lives in the nested model (e.g., `("static", "camera", "capture_frame_rate")`). The traversal finds all such entries and creates accessors that route reads and writes through the nested path.
+
+This means adding a new field to the spec requires only:
+1. Adding a Pydantic field with correct `json_schema_extra` (including `clip_property` path)
+2. No accessor code; the framework synthesizes it
+
+### Frame operations
+
+- `clip.append(other_clip)` — concatenates dynamic tuple fields from `other_clip` onto `self`. Used to build multi-frame clips from per-frame reads (see MoSys reader).
+- `clip[i]` (`__getitem__`) — extracts frame `i` as a new single-frame `Clip`.
+- `clip.to_json()` — serializes to a JSON-compatible dict, excluding fields set to their defaults (compact wire format).
+
+## Schema Generation and Compatibility Layer
+
+`compatibility.py` provides two coupled responsibilities:
+
+### CompatibleBaseModel
+
+All camdkit domain types inherit from `CompatibleBaseModel` rather than Pydantic's `BaseModel`. This configures:
+- `populate_by_name=True` — allow both alias and Python name for construction
+- `validate_assignment=True` — validate on every field write
+- `use_enum_values=True` — store enum values not members
+- `extra='forbid'` — reject unknown fields
+- `use_attribute_docstrings=True` — use field docstrings for schema descriptions
+
+It also adds class-level `validate()`, `to_json()`, `from_json()`, and `make_json_schema()` methods.
+
+### Schema surgery
+
+Pydantic v2's generated JSON Schema is verbose and internal. `CompatibleSchemaGenerator` post-processes it:
+
+1. **Ref resolution** — calls `jsonref.replace_refs()` to inline all `$ref` pointers, producing a self-contained schema document.
+2. **Layer removal** — `model_field_schema()` strips Pydantic-internal wrapping layers:
+   - `default` layer (the outermost wrapper when a field has a default) → unwrapped to the inner schema
+   - `nullable` / `anyOf` layer (Pydantic's `Optional[T]` encoding) → unwrapped to `T`
+   - `tuple` layer (Pydantic's encoding of `tuple[T, ...]`) → unwrapped to array schema for the element type
+   
+   This produces a schema that says `{"type": "array", "items": {...}}` rather than Pydantic's layered internal representation.
+
+3. **Two schema modes** — `InternalCompatibleSchemaGenerator` retains `clip_property` metadata (used by `setup_clip_properties()`). `ExternalCompatibleSchemaGenerator` strips it (used for the published OpenTrackIO schema).
+
+### Description canonicalization
+
+`canonicalize_descriptions()` ensures field descriptions comply with PEP 257 single-newline rules before schema export.
+
+## Public API Facades
+
+`framework.py` and `model.py` are thin re-export modules. They exist to:
+- Flatten the import surface (`from camdkit.model import Clip, Dimensions` rather than importing from four sub-modules)
+- Apply public-facing name aliases (e.g., `SenselDimensions` is exported as `Dimensions`)
+- Provide a stable public API even if internal module structure changes
+
+`framework.py` focuses on type re-exports. `model.py` adds `Clip` and a second set of namespace-prefixed aliases (e.g., `LensEncoders`, `TimingTimecode`).
+
+## Versioning
+
+`versioning_types.py` defines `VersionedProtocol` with `name` ("OpenTrackIO") and `version` (3-tuple of single-digit ints). The current version is `(1, 0, 1)`. The constructor enforces that `name == "OpenTrackIO"` — only one protocol is supported.
+
+`OPENTRACKIO_PROTOCOL_NAME` and `OPENTRACKIO_PROTOCOL_VERSION` constants are re-exported through `framework.py` and `model.py`.
+
+## Primitive Foundation
+
+The following modules underpin all domain types in the codebase:
+
+| Module | Role |
+|---|---|
+| `numeric_types.py` | Constrained int/float types (`NonNegativeInt`, `StrictlyPositiveRational`, etc.) and `Rational`/`StrictlyPositiveRational` model classes |
+| `string_types.py` | `NonBlankUTF8String` (1–1023 chars) and `UUIDURN` (RFC 4122 pattern) |
+| `units.py` | String constants for unit annotations used in `json_schema_extra` |
+| `utils.py` | `guess_fps(fps)` — converts approximate float FPS to exact `Fraction` (handles 23.98→24000/1001, etc.) |
+
+These are owned by Protocol Envelope because they have no domain-specific knowledge — they are pure infrastructure used by every cluster.
+
+## Examples
+
+`examples.py` provides four canonical `Clip` instances:
+
+| Function | Description |
+|---|---|
+| `get_recommended_static_example()` | Minimal static metadata (required fields only) |
+| `get_complete_static_example()` | All static fields populated |
+| `get_recommended_dynamic_example()` | Minimal per-frame data |
+| `get_complete_dynamic_example()` | All dynamic fields populated, including PTP sync |
+
+These serve two purposes: regression testing (compared against committed JSON files) and documentation (rendered in the HTML output). They are also the primary consumers of `_unwrap_clip_to_pseudo_frame()`, which extracts a single-frame view for use in schema validation tests.
+
+## Decisions & Alternatives
+
+| Decision | Chosen | Alternatives Considered | Rationale |
+|---|---|---|---|
+| Schema-driven property synthesis | `setup_clip_properties()` + `traverse_json_schema()` at class definition time | Hand-coded properties per field | [inferred] Reduces maintenance burden when spec adds new fields; properties stay in sync with schema automatically |
+| Tuple-based multi-frame storage | `tuple[T, ...]` per dynamic field | List, separate `Frame` container class, separate `Clip` + `ClipStream` | [inferred] Tuples are immutable (safe default for value semantics); avoids a second container class; append semantics are explicit |
+| Single `Clip` for both static and multi-frame | `Clip.Static` nested inside `Clip` | Separate `StaticClip` and `DynamicClip` | [inferred] Consumers always get one object; no type branching at call sites |
+| Schema layer removal in `CompatibleSchemaGenerator` | Strip Pydantic-internal wrapping (default, anyOf, tuple layers) | Accept Pydantic output as-is; use a custom Pydantic plugin | [inferred] Classic camdkit 0.9 schema format predates Pydantic rewrite; consumers depend on that format |
+| Inline all `$ref` via `jsonref` | Fully self-contained schema document | Keep `$ref` pointers | [inferred] OpenTrackIO schema is distributed as a single file; external $ref resolution is not guaranteed for all consumers |
+| Two schema generators (internal vs external) | `InternalCompatibleSchemaGenerator` (retains `clip_property`) / `ExternalCompatibleSchemaGenerator` (strips it) | Single generator with a mode flag | [inferred] Keeps the property synthesis machinery separate from the published spec schema |
+| `CompatibleBaseModel` for all domain types | Shared base with custom config | Per-class Pydantic `model_config` | [inferred] Ensures uniform serialization and validation behavior across all 10+ domain type modules |
+| Positional `__init__` constructors | Override Pydantic's keyword-only constructors | Keyword-only (Pydantic default) | Explicit: camdkit 0.9 compatibility — existing call sites use positional args |
+
+## Open Questions & Future Decisions
+
+### Resolved
+1. ✅ Whether to use Pydantic v2 — yes, full rewrite in 1.0.0 (49 files, 2953 del, 7461 add per CHANGELOG)
+
+### Deferred
+1. Schema layer merge hazard: `remove_layer()` has a known fragility when merging `min_length`/`max_length` constraints across layers (TODO comment at `compatibility.py:192`). Needs a regression test before any schema surgery changes.
+2. `examples.py` uses hardcoded index-[0] unwrapping paths to convert multi-frame clips to single-frame pseudo-frames. This is noted as brittle to schema changes — evaluate replacing with a generic frame-index approach.
+3. `versioning_types.py:31` — f-string bug: error message in constructor uses `{OPENTRACKIO_PROTOCOL_NAME}` inside a plain string, not an f-string. Message would print literally rather than interpolating the constant.
+4. `units.py` — `__ALL__` typo (should be `__all__`); `METERS_AND_DEGREES` flagged as a "confusing non-unit" with a TODO to remove in favor of separate unit strings.
+
+## References
+
+- Files in this cluster:
+  - `src/main/python/camdkit/clip.py`
+  - `src/main/python/camdkit/compatibility.py`
+  - `src/main/python/camdkit/framework.py`
+  - `src/main/python/camdkit/model.py`
+  - `src/main/python/camdkit/versioning_types.py`
+  - `src/main/python/camdkit/numeric_types.py`
+  - `src/main/python/camdkit/string_types.py`
+  - `src/main/python/camdkit/units.py`
+  - `src/main/python/camdkit/utils.py`
+  - `src/main/python/camdkit/examples.py`
+  - `src/tools/python/generate_opentrackio_schema.py`
+  - `src/tools/python/generate_component_schemas.py`
+- Dependencies on other clusters: all domain type clusters depend on this cluster's `CompatibleBaseModel`, `numeric_types`, `string_types`, `units`; Format Bridge readers produce `Clip` instances defined here
+- External dependencies: `pydantic`, `pydantic_core`, `jsonref`, `fractions`, `uuid`, `copy`

--- a/docs/llds/spatial-tracking.md
+++ b/docs/llds/spatial-tracking.md
@@ -1,0 +1,218 @@
+# Spatial Tracking
+
+## Context and Design Philosophy
+
+Spatial Tracking covers everything related to where the camera is in 3D space: its position and orientation as `Transform` data, the tracker device's dynamic state (`Tracker`), its global geodetic position (`GlobalPosition`), and the Mo-Sys F4 binary protocol that is the primary live tracking data source.
+
+This cluster is the most protocol-specific in the codebase. While ARRI, RED, Venice, and Canon readers extract static device metadata from production files, the Mo-Sys F4 reader decodes a live-streaming binary wire protocol carrying per-frame spatial and optical data. The F4 packet parser (`f4.py`) is the most complex single file in the project — it was ported from C++ and drives the richest `Clip` population of any reader.
+
+## Transform Types
+
+`transform_types.py` defines the 3D spatial primitives.
+
+### Vector3
+
+Three nullable floats representing a point or displacement in meters:
+
+```
+Vector3: { x: float | None, y: float | None, z: float | None }
+```
+
+All three fields are `float | None` in the Pydantic model, but the positional `__init__` constructor requires all three to be provided. This is a type-annotation/constructor mismatch — the field type allows `None` but the constructor signature does not. The practical effect is that `None` can only be assigned post-construction via attribute assignment.
+
+Units annotation (METER) is present in the LLD but is **commented out** in `json_schema_extra` on `Vector3` and `Rotator3`. The comments indicate this was stripped intentionally, but no explanation is recorded.
+
+### Rotator3
+
+Three nullable floats representing orientation in degrees:
+
+```
+Rotator3: { pan: float | None, tilt: float | None, roll: float | None }
+```
+
+Same nullable/constructor mismatch as `Vector3`.
+
+### Transform
+
+The primary per-frame spatial record:
+
+```
+Transform:
+  translation: Vector3      # required, position in meters
+  rotation:    Rotator3     # required, orientation in degrees
+  scale:       Vector3      # optional, scale factors per axis
+  id:          str | None   # optional, named reference (e.g. "Camera", "Lens")
+```
+
+`id` allows a single frame to carry multiple named transforms (e.g., camera body + lens nodal point). The `transforms` field on `Clip` is `tuple[tuple[Transform, ...], ...]` — an outer tuple per frame, inner tuple of one or more `Transform` objects per frame.
+
+`transform_types.py` also contains an unused import: `from multiprocessing.context import DefaultContext` (line 8). This is dead code.
+
+## Tracker Dynamic State
+
+`tracker_types.py` defines `Tracker` — the per-frame dynamic state of the tracking device — and `GlobalPosition`.
+
+### Tracker
+
+```
+Tracker:
+  notes:     tuple[str, ...]   # optional, free-text per frame
+  recording: tuple[bool, ...]  # optional, recording flag per frame
+  slate:     tuple[str, ...]   # optional, slate identifier per frame
+  status:    tuple[str, ...]   # optional, status string per frame
+```
+
+All four fields are unconstrained tuples — no `min_length` requirement. Empty tuples are valid. This may be unintentional given that `FizEncoders` and similar types enforce "at least one" constraints.
+
+`status` in practice carries strings like `"Optical Good"` from the Mo-Sys F4 protocol.
+
+### GlobalPosition
+
+Represents the camera's position in the real world using an ENU (East-North-Up) local tangent plane with a geodetic anchor:
+
+```
+GlobalPosition:
+  E, N, U:        float   # local tangent plane coordinates (meters)
+  lat0, lon0, h0: float   # geodetic origin (degrees, degrees, meters)
+```
+
+All six fields are required at construction. No range validation exists on any field — latitude, longitude, and height are accepted as arbitrary floats. The ENU coordinate system is documented via a Wikipedia link in the source (`tracker_types.py:67`).
+
+## Mo-Sys F4 Protocol
+
+The Mo-Sys F4 binary protocol is a streaming wire format for tracking data. The parser in `mosys/f4.py` was ported from C++ and is the most complex file in the project.
+
+### Packet structure
+
+```
+[0xf4]  command byte (identifies F4 packet)
+[u8]    camera_id
+[u8]    axis_count
+[u8]    status
+[5 × axis_count bytes]  axis blocks
+[u8]    checksum  (XOR of all preceding bytes with 0x40)
+```
+
+Each axis block:
+```
+[u8]  axis_id
+[u8]  axis_status  (encodes frame rate as 2-bit field in bits 6-7)
+[u8]  data_bits1
+[u8]  data_bits2
+[u8]  data_bits3
+```
+
+Checksum is validated by `_compute_f4_checksum()`. Signed 24-bit and 32-bit integers use two's complement arithmetic implemented in helper methods.
+
+### Axis ID → OpenTrackIO field mapping
+
+Selected mappings (full table in `f4.py` constants class `F4`):
+
+| Axis ID | Field | Notes |
+|---|---|---|
+| `0x01` | pan (rotation) | Degrees |
+| `0x02` | tilt (rotation) | Degrees |
+| `0x03` | roll (rotation) | Degrees |
+| `0x04` | x (translation) | Millimeters → meters |
+| `0x05` | y (translation) | Millimeters → meters |
+| `0x06` | z (translation) | Millimeters → meters |
+| `0x10` | focus encoder | Normalized [0,1] |
+| `0x11` | iris encoder | Normalized [0,1] |
+| `0x12` | zoom encoder | Normalized [0,1] |
+| `0x2E` | f-number | — |
+| `0x2F` | focus distance | Meters |
+| `0x3C` | pinhole focal length | mm; computed from 35mm sensor assumption |
+| `0x3E` | entrance pupil offset | Meters |
+| `0x50` | projection offset x | — |
+| `0x51` | projection offset y | — |
+| `0x40`–`0x47` | distortion radial coefficients | Up to 8 coefficients |
+
+### get_tracking_frame()
+
+`F4PacketParser.get_tracking_frame()` uses Python 3.10+ `match`/`case` to dispatch on axis IDs and build a `Clip` object with one frame of data. It:
+1. Generates fresh `uuid4()` for `sample_id` and `source_id` on every frame
+2. Sets `protocol` to `OPENTRACKIO_PROTOCOL_NAME` / `OPENTRACKIO_PROTOCOL_VERSION`
+3. Extracts timecode from the packet status byte (frame rate encoded as 2-bit field)
+4. Populates `timing.synchronization` with sequence number and lock status
+5. Assembles `Transform(translation=Vector3(...), rotation=Rotator3(...))` from pan/tilt/roll/x/y/z axes
+6. Populates `Lens` fields: encoders, distortions, projection offset, f-number, focal length, focus distance, entrance pupil
+
+**Sensor assumption:** Focal length conversion uses a hardcoded 35mm full-frame sensor (36×24mm) at `f4.py:287`. This is correct for some Mo-Sys rigs but wrong for others; there is no mechanism to configure the sensor size.
+
+### Reader accumulation pattern
+
+`mosys/reader.py` reads frames sequentially:
+
+```python
+# to_clip() accumulation pattern
+clip = None
+for frame in f4_frames:
+    frame_clip = to_frame(data)
+    if clip is None:
+        clip = frame_clip
+    else:
+        clip.append(frame_clip)
+```
+
+This uses `Clip.append()` to grow tuple fields. The first frame's `Clip` becomes the base; subsequent frames' tuples are concatenated onto it.
+
+`to_frames()` does the reverse: reads a full clip, then extracts individual frames via `clip[i].to_json()`.
+
+### CLI limitation
+
+`mosys/cli.py` hardcodes reading the first 10 frames and outputs only frame 0 to stdout. This makes it unsuitable as a general-purpose conversion tool; it is effectively a diagnostic/demo utility.
+
+## Coordinate System
+
+The OpenTrackIO coordinate system is documented in:
+- `src/main/resources/lyx/OpenCV_to_OpenTrackIO.lyx` / `.tex` — derivation of the transform from OpenCV camera coordinates to OpenTrackIO
+- `src/main/resources/res/OpenCV_to_OpenTrackIO.pdf` — compiled reference
+
+Rotation is expressed as pan/tilt/roll (extrinsic Euler angles), not a quaternion or rotation matrix. Translation is in meters; rotation in degrees.
+
+## Decisions & Alternatives
+
+| Decision | Chosen | Alternatives Considered | Rationale |
+|---|---|---|---|
+| F4 parser as Python port from C++ | Direct port of field-ID dispatch logic | Clean-room Python reimplementation | [inferred] F4 spec is stable; porting preserves verified behavior; original C++ had been tested against real hardware |
+| `match`/`case` for axis dispatch | Python 3.10+ structural pattern matching | `if`/`elif` chain, dict dispatch | [inferred] Clean expression of the field-ID dispatch pattern; requires Python 3.10+ (project requires 3.11 per Pipfile) |
+| UUID per frame for sample_id / source_id | `uuid4()` generated fresh each frame | Deterministic UUID from frame content | [inferred] Live streaming context — no stable frame content to hash; random UUID is the safe default |
+| `Transform.id` as optional string | Free-form label | Enum of known transform types | [inferred] Future-proofing — new named transforms (e.g., "Nodal", "Entrance Pupil") don't require schema changes |
+| `transforms` as tuple of tuples | `tuple[tuple[Transform, ...], ...]` | `tuple[Transform, ...]` (one per frame) | [inferred] Supports multi-transform frames (camera body + lens nodal point as separate named transforms) |
+| Vector3/Rotator3 fields nullable | `float | None` on all component fields | Non-nullable floats | [inferred] Allows partial transform data — a tracker might report rotation but not position |
+| GlobalPosition no range validation | All floats unconstrained | Validate lat ∈ [-90,90], lon ∈ [-180,180] | [inferred] Simplicity; validation burden deferred to consumer |
+| Hardcoded 36×24mm sensor in F4 parser | Constant in `f4.py:287` | Configurable sensor parameter | [inferred] Mo-Sys rigs in the test corpus are 35mm; no mechanism existed to pass sensor metadata through the F4 protocol |
+
+## Open Questions & Future Decisions
+
+### Resolved
+1. ✅ Coordinate system derivation documented (OpenCV_to_OpenTrackIO.pdf)
+
+### Deferred
+1. `f4.py:287` — hardcoded 36×24mm sensor assumption. No mechanism to configure sensor size per rig. Blocks correct focal length computation for non-35mm cameras.
+2. `transform_types.py:8` — unused import `from multiprocessing.context import DefaultContext`. Should be removed.
+3. `Vector3` and `Rotator3` — `json_schema_extra` units annotations are commented out. Reason is not recorded. If units are intentionally absent from the schema, this should be documented; if it was an accidental omission, they should be restored.
+4. `Vector3`/`Rotator3` constructor/field type mismatch: fields are `float | None` but positional `__init__` requires non-None values. Decide whether to make fields non-nullable (simpler) or make the constructor accept None (consistent).
+5. `Tracker` tuple fields have no `min_length` constraint — empty tuples are valid. Evaluate whether this is intentional (empty status is meaningful) or an oversight.
+6. `mosys/cli.py` hardcodes first 10 frames / frame 0 output. Not useful as a general converter. Evaluate aligning with other reader CLIs (full clip → stdout JSON).
+7. `GlobalPosition` has no range validation. Consider validating lat ∈ [-90, 90], lon ∈ [-180, 180] at a minimum.
+
+## References
+
+- Files owned by this cluster:
+  - `src/main/python/camdkit/transform_types.py`
+  - `src/main/python/camdkit/tracker_types.py` (dynamic classes: `Tracker`, `GlobalPosition`)
+  - `src/main/python/camdkit/mosys/f4.py`
+  - `src/main/python/camdkit/mosys/reader.py`
+  - `src/main/python/camdkit/mosys/cli.py`
+  - `src/main/python/camdkit/mosys/__init__.py`
+- Files cross-referenced (static sub-class only):
+  - `src/main/python/camdkit/tracker_types.py` → `StaticTracker` (owned by Camera Identity)
+- Coordinate system reference:
+  - `src/main/resources/lyx/OpenCV_to_OpenTrackIO.lyx`
+  - `src/main/resources/res/OpenCV_to_OpenTrackIO.pdf`
+- Dependencies on other clusters:
+  - Protocol Envelope: `CompatibleBaseModel`, `NonBlankUTF8String`, `BOOLEAN`, `units`, `Clip`, `OPENTRACKIO_PROTOCOL_NAME`, `OPENTRACKIO_PROTOCOL_VERSION`
+  - Optical Characteristics: `FizEncoders`, `Distortion`, `ProjectionOffset` (populated by F4 parser)
+  - Temporal Synchronization: `Timecode`, `Synchronization` (populated by F4 parser)
+- External dependencies: `math`, `struct`, `uuid`, `pydantic`

--- a/docs/llds/temporal-synchronization.md
+++ b/docs/llds/temporal-synchronization.md
@@ -174,7 +174,7 @@ This is the normative example of how a broadcast-grade PTP-synchronized camera s
 3. `FrameRate` subclass pattern conflates value type and documentation carrier. If `FrameRate` instances are never used as runtime field values, consider replacing with a plain dataclass or constants dict.
 4. No reader other than Mo-Sys populates `timing.sample_timestamp`. For production file workflows (ARRI, RED, Venice, Canon, BMD), consumers receive no wall-clock timestamp even when one could be inferred from clip metadata.
 5. Mo-Sys F4 reader does not populate `timing.recorded_timestamp`. The F4 protocol carries timecode but not a full UTC/TAI timestamp. This gap may be intentional or a missing feature.
-6. `domain` field on `SynchronizationPTP` is annotated `[0..255]` in the field but the spec domain is `[0..127]`. Tests validate up to 127. The model accepts values 128–255 which are technically out of spec for most PTP profiles.
+6. ~~`domain` accepts 128–255~~: The model correctly enforces `[0..127]` via `NonNegative8BitInt` (MAX_INT_8). Values ≥ 128 are rejected by the validator. No gap exists here.
 
 ## References
 

--- a/docs/llds/temporal-synchronization.md
+++ b/docs/llds/temporal-synchronization.md
@@ -1,0 +1,186 @@
+# Temporal Synchronization
+
+## Context and Design Philosophy
+
+Temporal Synchronization covers everything related to *when* a sample was captured: SMPTE timecode, hardware timestamps, sync lock status, IEEE 1588 PTP (Precision Time Protocol) configuration, and the timing mode that governs how the sample clock relates to an external reference.
+
+All timing fields are dynamic — per-frame tuples on `Clip`. There are no static timing fields. This reflects the physical reality: sync lock can be lost mid-clip, sequence numbers always advance, and timestamps are inherently per-sample.
+
+The cluster is contained entirely within `timing_types.py`. Of the six readers, only the Mo-Sys F4 reader populates timing fields; the other five readers work with production files that carry no live synchronization metadata.
+
+## Type Inventory
+
+### Enums
+
+| Enum | Values | Notes |
+|---|---|---|
+| `TimingMode` | `internal`, `external` | Whether the camera clock is freerunning or locked to an external reference |
+| `SynchronizationSourceEnum` | `genlock`, `videoIn`, `ptp`, `ntp` | What signal the sync is locked to |
+| `PTPProfile` | `IEEE 1588-2019`, `IEEE 802.1AS-2020`, `SMPTE ST2059-2:2021` | PTP profile variant |
+| `PTPLeaderTimeSource` | `GNSS`, `Atomic clock`, `NTP` | What the PTP grandmaster clock is locked to |
+| `Sampling` | `static`, `regular` | Whether values are sampled per frame or are static for the clip |
+
+All enums use `StrEnum` + `@unique` enforcement.
+
+### Timecode
+
+SMPTE timecode for a single frame:
+
+```
+Timecode:
+  hours:      int [0..23]
+  minutes:    int [0..59]
+  seconds:    int [0..59]
+  frames:     int [0..119]       # upper bound is format-dependent
+  frame_rate: StrictlyPositiveRational
+  sub_frame:  uint32             # sub-frame offset
+  dropFrame:  bool | None        # drop-frame flag
+```
+
+The `frames` field is validated against `frame_rate` by `check_frames_allowed_by_format()`: it checks `frames < math.ceil(Fraction(frame_rate.num, frame_rate.denom))`. This means a 24fps timecode rejects `frames >= 24`, a 29.97fps timecode rejects `frames >= 30`. The upper bound of 119 in the field annotation covers 120fps as the maximum supported rate.
+
+`sub_frame` is a `uint32` that subdivides one frame into finer increments. Its interpretation depends on the system; the spec does not mandate a specific sub-frame unit.
+
+### Timestamp
+
+A 64-bit hardware timestamp split into seconds and nanoseconds:
+
+```
+Timestamp:
+  seconds:     uint48   # TAI or PTP epoch seconds
+  nanoseconds: uint32   # sub-second nanoseconds [0..999999999]
+```
+
+`seconds` uses `NonNegative48BitInt` (max value 2^48 − 1 ≈ year 10889 from epoch). `nanoseconds` is a plain `NonNegativeInt`; no upper bound of 999999999 is enforced in the model.
+
+### SynchronizationPTP
+
+The most complex type in the cluster. Carries the full IEEE 1588 grandmaster clock description:
+
+```
+SynchronizationPTP:
+  profile:           PTPProfile enum
+  domain:            int [0..127]     # PTP domain number
+  leader_identity:   str              # MAC-like hex string (colon or dash separated)
+  leader_priorities: SynchronizationPTPPriorities  # { priority1, priority2 ∈ [0..255] }
+  leader_accuracy:   uint8 [0..254]   # clock accuracy class
+  leader_time_source: PTPLeaderTimeSource enum
+  mean_path_delay:   uint32           # nanoseconds, one-way network delay
+  vlan:              uint16           # VLAN ID [0..65535]
+```
+
+`leader_identity` matches `PTP_LEADER_PATTERN` — a regex for MAC-address-like hex strings that supports both colon and dash separators. The pattern uses explicit alternation rather than backreferences because Pydantic v2 does not support regex backreferences.
+
+`SynchronizationPTP` is the only type in the project with an extensive embedded docstring (lines 233–276 in `timing_types.py`) that explains each field's meaning and source. This was noted as a design pattern for "metadata transparency."
+
+### Synchronization
+
+The per-frame sync status container:
+
+```
+Synchronization:
+  locked:    bool
+  source:    SynchronizationSourceEnum
+  frequency: StrictlyPositiveRational   # sync signal frequency (Hz)
+  offsets:   SynchronizationOffsets | None
+  present:   bool | None
+  ptp:       SynchronizationPTP | None  # present only when source == ptp
+```
+
+`SynchronizationOffsets` carries calibration offsets applied to the sync signal:
+
+```
+SynchronizationOffsets:
+  translation:   float | None   # temporal offset applied to position data
+  rotation:      float | None   # temporal offset applied to rotation data
+  lensEncoders:  float | None   # temporal offset applied to lens encoder data
+```
+
+All three offset fields are optional in the Pydantic model, but the `__init__` signature lists them as required positional args with no defaults. This is a constructor signature inconsistency (matching the pattern seen in other types for 0.9 compatibility) that conflicts with the optional field types.
+
+### Timing
+
+The top-level per-frame timing container on `Clip`:
+
+```
+Timing:
+  mode:                tuple[TimingMode, ...]
+  recorded_timestamp:  tuple[Timestamp, ...] | None
+  sample_rate:         StrictlyPositiveRational       # single value, not per-frame
+  sample_timestamp:    tuple[Timestamp, ...]
+  sequence_number:     tuple[int, ...]
+  synchronization:     tuple[Synchronization, ...]
+  timecode:            tuple[Timecode, ...]
+```
+
+`sample_rate` is the one non-tuple field: it is a single rational value for the whole clip, not per-frame. A `@field_validator` (mode "before") coerces the input to `StrictlyPositiveRational`, handling both scalar inputs and tuple inputs (it extracts element [0] from a tuple, which is the pattern used when setting from a Clip accessor).
+
+### FrameRate
+
+`FrameRate` is a nominal subclass of `StrictlyPositiveRational` that adds documentation metadata:
+
+```
+FrameRate(StrictlyPositiveRational):
+  canonical_name: str    # e.g. "24" or "23.976"
+  sampling:       str    # "regular" or "static"
+  units:          str    # always "1/s" (Hz)
+  section:        str    # spec section reference
+```
+
+These are class-level metadata fields, not instance data. `FrameRate` is not used as a field type anywhere in the model — it exists to attach documentation metadata to specific well-known frame rates for schema/documentation generation. This is an unusual inheritance pattern that conflates a value type with a documentation carrier.
+
+## Per-Frame Timing Data Flow
+
+Only the Mo-Sys F4 reader populates timing fields. The F4 packet provides:
+- **Timecode** — encoded in the packet status byte; frame rate is a 2-bit field (four possible values: 24, 25, 30, 30000/1001 fps)
+- **Sequence number** — extracted from F4 axis data
+- **Synchronization** — lock status, source, and PTP configuration if applicable
+- **Sample timestamp** — not directly from F4; the F4 protocol does not carry wall-clock timestamps; the Mo-Sys reader does not populate `sample_timestamp`
+
+The five non-Mo-Sys readers do not populate any `Timing` fields. Static production files (CSV, XML, text) carry no live synchronization metadata.
+
+## Relationship to OpenTrackIO Wire Format
+
+The complete dynamic example (`examples.py`) demonstrates the full PTP configuration:
+- `synchronization.source = "ptp"`
+- `synchronization.ptp.profile = PTPProfile.SMPTE_ST_2059_2` (broadcast standard)
+- `synchronization.ptp.domain` — network domain number
+- `synchronization.ptp.leader_identity` — grandmaster MAC address
+- `synchronization.ptp.leader_time_source = PTPLeaderTimeSource.GNSS`
+- `synchronization.ptp.mean_path_delay` — one-way network delay in nanoseconds
+
+This is the normative example of how a broadcast-grade PTP-synchronized camera should report its timing state.
+
+## Decisions & Alternatives
+
+| Decision | Chosen | Alternatives Considered | Rationale |
+|---|---|---|---|
+| All timing fields as per-frame tuples | `tuple[T, ...]` for every Timing field | Static values for mode and sample_rate | [inferred] Sync lock can be lost mid-clip; mode can change; tuple semantics are consistent with rest of dynamic fields |
+| `sample_rate` as single value, not tuple | `StrictlyPositiveRational` scalar | `tuple[StrictlyPositiveRational, ...]` | [inferred] Sample rate is a clip-level property, not per-frame; a variable sample rate clip is not a supported use case |
+| Timecode frame validation via `math.ceil(Fraction(...))` | Validate `frames < ceil(num/denom)` | Validate against an integer lookup table | [inferred] Handles non-integer frame rates (e.g., 30000/1001) without a hardcoded table; `Fraction` arithmetic is exact |
+| PTP_LEADER_PATTERN with explicit alternation | `([0-9a-f]{2}[:-]){5}[0-9a-f]{2}` | Backreference to enforce consistent separator | Explicit: Pydantic v2 does not support regex backreferences; comment documents this |
+| `SynchronizationPTP` embedded docstring | Inline field-by-field documentation in the class body | External spec reference only | [inferred] Self-contained field documentation is valuable when the schema is published without the source code |
+| `FrameRate` as `StrictlyPositiveRational` subclass | Subclass with metadata fields | Standalone dataclass; annotated constant | [inferred] Allows `FrameRate` instances to be used wherever a `StrictlyPositiveRational` is accepted while carrying documentation metadata |
+| `Timestamp` split as seconds + nanoseconds | Two fields (`uint48` + `uint32`) | Single `uint64` nanoseconds since epoch | [inferred] Avoids 64-bit integer precision loss in Python/JSON; matches common PTP wire format conventions |
+
+## Open Questions & Future Decisions
+
+### Resolved
+1. ✅ PTP profile enum values match SMPTE ST2059-2:2021 and IEEE 1588-2019 / 802.1AS-2020
+
+### Deferred
+1. `SynchronizationOffsets.__init__` lists all three params as required positional args, but all three fields are `float | None` in the model. Decide whether to make the constructor match the field types (accept `None`) or make the fields non-nullable.
+2. `Timestamp.nanoseconds` is `NonNegativeInt` with no upper bound of 999,999,999 enforced. A value of 1,500,000,000 nanoseconds is accepted — which is invalid (exceeds one second). Consider adding `lt=1_000_000_000`.
+3. `FrameRate` subclass pattern conflates value type and documentation carrier. If `FrameRate` instances are never used as runtime field values, consider replacing with a plain dataclass or constants dict.
+4. No reader other than Mo-Sys populates `timing.sample_timestamp`. For production file workflows (ARRI, RED, Venice, Canon, BMD), consumers receive no wall-clock timestamp even when one could be inferred from clip metadata.
+5. Mo-Sys F4 reader does not populate `timing.recorded_timestamp`. The F4 protocol carries timecode but not a full UTC/TAI timestamp. This gap may be intentional or a missing feature.
+6. `domain` field on `SynchronizationPTP` is annotated `[0..255]` in the field but the spec domain is `[0..127]`. Tests validate up to 127. The model accepts values 128–255 which are technically out of spec for most PTP profiles.
+
+## References
+
+- Files owned by this cluster:
+  - `src/main/python/camdkit/timing_types.py` (all of it)
+- Dependencies on other clusters:
+  - Protocol Envelope: `CompatibleBaseModel`, `NonBlankUTF8String`, `StrictlyPositiveRational`, `NonNegative8BitInt`, `StrictlyPositive8BitInt`, `NonNegativeInt`, `NonNegative48BitInt`, `NonNegativeFloat`, `units`
+- Populated by: Mo-Sys F4 reader (timecode, synchronization, sequence number, timing mode); no other reader populates timing fields
+- External dependencies: `pydantic`, `enum`, `fractions`, `math`

--- a/docs/specs/camera-identity-specs.md
+++ b/docs/specs/camera-identity-specs.md
@@ -1,0 +1,32 @@
+# Camera Identity Specs
+
+## StaticCamera
+
+- [x] **CAMID-CAM-001**: `StaticCamera` shall accept camera hardware metadata fields (`make`, `model`, `serial_number`, `firmware_version`, `label`, `capture_frame_rate`, `active_sensor_physical_dimensions`, `active_sensor_resolution`, `iso`, `fdl_link`, `shutter_angle`, `anamorphic_squeeze`) as individually optional with no required minimum set.
+- [x] **CAMID-CAM-002**: `PhysicalDimensions` shall constrain `height` and `width` to non-negative floats representing active sensor area in millimeters.
+- [x] **CAMID-CAM-003**: `SenselDimensions` shall constrain `height` and `width` to non-negative integers bounded by `MAX_INT_32`, representing active sensor photosite resolution in pixels.
+- [x] **CAMID-CAM-004**: `ShutterAngle` shall constrain values to the closed range `[0.0, 360.0]` degrees.
+- [x] **CAMID-CAM-005**: When setting `capture_frame_rate` or `anamorphic_squeeze` on `StaticCamera`, the system shall coerce the input to `StrictlyPositiveRational` before validation, accepting `int`, `Rational`, or `{"num": n, "denom": d}` dict inputs.
+- [x] **CAMID-CAM-006**: `fdl_link` shall be validated as a UUID URN matching the pattern `urn:uuid:{8hex}-{4hex}-{4hex}-{4hex}-{12hex}` with lowercase hex digits.
+
+## StaticLens
+
+- [x] **CAMID-LENS-001**: `StaticLens` shall accept lens hardware metadata fields (`make`, `model`, `serial_number`, `firmware_version`, `nominal_focal_length`, `calibration_history`, `overscan_percent`) as individually optional.
+- [x] **CAMID-LENS-002**: `StaticLens.nominal_focal_length` shall be a strictly positive integer in millimeters representing the marked prime or zoom label on the lens body.
+- [x] **CAMID-LENS-003**: `StaticLens.overscan_percent` shall be constrained to values greater than or equal to 1.0 (representing the minimum overscan factor required by this lens).
+- [x] **CAMID-LENS-004**: `StaticLens.calibration_history` shall be an unbounded tuple of non-blank strings each capped at 1023 characters.
+
+## StaticTracker
+
+- [x] **CAMID-TRK-001**: `StaticTracker` shall accept tracker hardware metadata fields (`make`, `model`, `serial_number`, `firmware_version`) as individually optional non-blank strings capped at 1023 characters.
+
+## Reader Coverage
+
+- [x] **CAMID-READ-001**: The ARRI reader shall populate `camera_model`, `camera_serial_number`, `iso`, `capture_frame_rate`, `shutter_angle`, `anamorphic_squeeze`, `lens_nominal_focal_length`, and `active_sensor_physical_dimensions` (for supported ALEXA LF variants) from the AME CSV.
+- [x] **CAMID-READ-002**: The BMD reader shall populate `camera_make`, `camera_model`, `camera_serial_number`, `camera_firmware`, `lens_model`, `iso`, `capture_frame_rate`, `shutter_angle`, `anamorphic_squeeze`, and `active_sensor_physical_dimensions` (for URSA Mini Pro 12K only) from the metadata text file.
+- [x] **CAMID-READ-003**: The Canon reader shall populate `camera_make` (hardcoded "Canon"), `iso`, `shutter_angle`, `anamorphic_squeeze`, and `lens_nominal_focal_length` from the static CSV.
+- [x] **CAMID-READ-004**: The RED reader shall populate `camera_make`, `camera_model`, `camera_serial_number`, `camera_firmware`, `lens_make`, `lens_model`, `lens_serial_number`, `iso`, `capture_frame_rate`, `shutter_angle`, `anamorphic_squeeze`, `lens_nominal_focal_length`, and `active_sensor_physical_dimensions` (for supported RED sensor variants) from the meta_3 CSV.
+- [x] **CAMID-READ-005**: The Venice reader shall populate `camera_make`, `camera_model`, `camera_serial_number`, `camera_firmware`, `lens_make`, `lens_model`, `lens_serial_number`, `iso`, `capture_frame_rate`, `shutter_angle`, `anamorphic_squeeze`, `lens_nominal_focal_length`, and `active_sensor_physical_dimensions` from the static XML.
+- [ ] **CAMID-READ-006**: The Canon reader shall populate `capture_frame_rate` from the Canon static CSV.
+- [ ] **CAMID-READ-007**: The Canon reader shall populate `active_sensor_physical_dimensions` from Canon sensor metadata.
+- [ ] **CAMID-READ-008**: The BMD reader shall populate `active_sensor_physical_dimensions` for BMD camera models other than the URSA Mini Pro 12K.

--- a/docs/specs/format-bridge-specs.md
+++ b/docs/specs/format-bridge-specs.md
@@ -1,0 +1,43 @@
+# Format Bridge Specs
+
+## Shared Interface
+
+- [x] **BRIDGE-IFACE-001**: Each reader shall expose a `to_clip(*file_args) -> Clip` function that returns a `Clip` populated from proprietary camera metadata.
+- [x] **BRIDGE-IFACE-002**: Each reader CLI `main()` shall serialize the resulting `Clip` to JSON and write it to stdout.
+
+## ARRI Reader
+
+- [x] **BRIDGE-ARRI-001**: The ARRI reader `to_clip()` shall parse a tab-delimited AME CSV and populate `iso`, `camera_model`, `camera_serial_number`, `lens_model`, `lens_nominal_focal_length`, `capture_frame_rate`, `shutter_angle`, `anamorphic_squeeze`, and per-frame `lens_focus_distance` and `lens_t_number`.
+- [x] **BRIDGE-ARRI-002**: `t_number_from_linear_iris_value(lin_value)` shall convert a linear iris integer from the ARRI CSV to an approximate T-stop via threshold comparison against standard T-stop values, returning `None` if no match is found.
+- [x] **BRIDGE-ARRI-003**: The ARRI reader shall compute `active_sensor_physical_dimensions` from a hardcoded pixel pitch lookup table keyed on camera model string, for supported ALEXA LF variants.
+- [ ] **BRIDGE-ARRI-004**: The ARRI reader shall populate `lens_entrance_pupil_offset` from the entrance pupil field in the AME CSV.
+- [ ] **BRIDGE-ARRI-005**: If the ARRI CSV contains a lens distance unit other than `"Meter"`, the system shall raise `ValueError` with a descriptive message (currently uses `assert`, which raises `AssertionError` and is stripped by `-O`).
+
+## BMD Reader
+
+- [x] **BRIDGE-BMD-001**: The BMD reader `to_clip()` shall parse a Blackmagic RAW SDK metadata text file (key: value sections) and populate camera identity, optical, and per-frame lens fields.
+- [x] **BRIDGE-BMD-002**: The BMD reader shall compute `active_sensor_physical_dimensions` for the Blackmagic URSA Mini Pro 12K.
+- [ ] **BRIDGE-BMD-003**: If the BMD metadata text contains no frame sections, the system shall raise `ValueError` with a descriptive message (currently `raise "string"` which raises `TypeError` — a bug at `bmd/reader.py:45`).
+- [ ] **BRIDGE-BMD-004**: The BMD reader shall extract `lens_focus_distance`, `lens_focal_length`, and `lens_t_number` regardless of whether the shutter metadata key is present (currently these are inside the `if shutter_value is not None:` block at `bmd/reader.py:112–123` — a logic bug).
+
+## Canon Reader
+
+- [x] **BRIDGE-CANON-001**: The Canon reader `to_clip()` shall parse a static CSV and per-frame CSV, populating `iso`, `shutter_angle`, `anamorphic_squeeze`, `lens_nominal_focal_length`, per-frame `lens_focus_distance`, and per-frame aperture.
+- [x] **BRIDGE-CANON-002**: When `ApertureMode` is `2`, the Canon reader shall populate `lens_t_number`; when `ApertureMode` is `1`, it shall populate `lens_f_number`.
+- [x] **BRIDGE-CANON-003**: The Canon reader shall decode `FocusPosition` from a hex-encoded IEEE 754 float32 string using `struct.unpack`.
+- [x] **BRIDGE-CANON-004**: The Canon reader shall map the `LensSqueezeFactor` enum (0→1.0, 1→1.33, 2→2.0, 3→1.8) to `anamorphic_squeeze`.
+
+## RED Reader
+
+- [x] **BRIDGE-RED-001**: The RED reader `to_clip()` shall parse meta_3 (static) and meta_5 (per-frame) REDline CSVs, populating full camera identity, sensor dimensions (for supported RED sensors), optical static fields, and per-frame `lens_focus_distance`, `lens_entrance_pupil_offset`, and `lens_t_number` from Cooke metadata.
+- [x] **BRIDGE-RED-002**: If the `Total Frames` field in meta_3 does not match the row count in meta_5, the RED reader shall raise `ValueError`.
+- [x] **BRIDGE-RED-003**: The RED reader shall compute `active_sensor_physical_dimensions` from a hardcoded pixel pitch lookup table keyed on the `Sensor Name` field, for supported RED sensor variants (RAPTOR, MONSTRO, KOMODO, HELIUM, GEMINI, DRAGON).
+
+## Venice Reader
+
+- [x] **BRIDGE-VENICE-001**: The Venice reader `to_clip()` shall parse a Sony Venice XML static file (namespace `urn:schemas-professionalDisc:nonRealTimeMeta:ver.2.10`) and per-frame CSV, populating full camera identity, sensor dimensions, and per-frame `lens_focus_distance`, `lens_t_number`, and `lens_nominal_focal_length`.
+- [x] **BRIDGE-VENICE-002**: If the clip duration in the Venice XML does not match the row count in the per-frame CSV, the Venice reader shall raise `ValueError`.
+- [x] **BRIDGE-VENICE-003**: `t_number_from_frac_stop()` shall parse T-stop strings in the formats `"T N"`, `"T N.D"`, and `"T N M/D"`, computing the T-stop value as `2^(aperture/2)`.
+- [x] **BRIDGE-VENICE-004**: The Venice reader shall convert focus distance from feet (CSV) to meters using the factor `12 × 25.4 / 1000`.
+- [x] **BRIDGE-VENICE-005**: The Venice reader shall convert shutter angle from hundredths of a degree (XML) to degrees by dividing by 100.
+- [ ] **BRIDGE-VENICE-006**: The Venice reader shall populate `lens_entrance_pupil_offset` from Venice metadata when present.

--- a/docs/specs/optical-characteristics-specs.md
+++ b/docs/specs/optical-characteristics-specs.md
@@ -1,0 +1,39 @@
+# Optical Characteristics Specs
+
+## Distortion Model
+
+- [x] **OPT-DIST-001**: `Distortion` shall require at least one radial coefficient in the `radial` tuple field.
+- [x] **OPT-DIST-002**: If `Distortion` is constructed with an empty `radial` tuple, the system shall raise a validation error.
+- [x] **OPT-DIST-003**: `Distortion.model` shall default to `"Brown-Conrady D-U"` when not specified.
+- [x] **OPT-DIST-004**: `Distortion.overscan` shall be constrained to values greater than or equal to 1.0 when present.
+- [x] **OPT-DIST-005**: The `Lens.distortions` field shall support multiple simultaneous `Distortion` models per frame as a tuple with at least one entry.
+
+## Encoders
+
+- [x] **OPT-ENC-001**: `FizEncoders` shall require at least one of `focus`, `iris`, or `zoom` to be non-None at construction time.
+- [x] **OPT-ENC-002**: `FizEncoders` fields (`focus`, `iris`, `zoom`) shall be constrained to the normalized range `[0.0, 1.0]`.
+- [x] **OPT-ENC-003**: `RawFizEncoders` shall require at least one of `focus`, `iris`, or `zoom` to be non-None at construction time.
+- [x] **OPT-ENC-004**: `RawFizEncoders` fields (`focus`, `iris`, `zoom`) shall be non-negative integers when present.
+
+## Geometric Offsets
+
+- [x] **OPT-OFFSET-001**: `DistortionOffset` and `ProjectionOffset` shall be distinct named types both representing a 2D planar offset (`x`, `y` floats), semantically distinguishing distortion center offset from projection center offset.
+
+## Exposure Falloff
+
+- [x] **OPT-FALLOFF-001**: `ExposureFalloff` shall hold three vignetting polynomial coefficients `a1`, `a2`, `a3` as floats.
+
+## Dynamic Lens Fields
+
+- [x] **OPT-LENS-001**: `Lens.focal_length` (JSON: `pinholeFocalLength`) shall represent the computed per-frame pinhole equivalent focal length in millimeters, distinct from `StaticLens.nominal_focal_length`.
+- [x] **OPT-LENS-002**: `Lens.focus_distance` shall represent per-frame focus distance in meters as a strictly positive float.
+- [x] **OPT-LENS-003**: `Lens.entrance_pupil_offset` shall represent the per-frame nodal point offset from the camera origin in meters.
+- [ ] **OPT-LENS-004**: The ARRI reader shall populate `lens_entrance_pupil_offset` from the entrance pupil field in the AME CSV.
+- [ ] **OPT-LENS-005**: The Venice reader shall populate `lens_entrance_pupil_offset` from Venice metadata when present.
+
+## Cooke /i Parser
+
+- [x] **OPT-COOKE-001**: `lens_data_from_binary_string()` shall extract `entrance_pupil_position` as a signed value from a 14-bit field spanning bytes 25–26 of the Cooke binary payload, with sign encoded in bit 5 of byte 25.
+- [x] **OPT-COOKE-002**: `lens_data_from_binary_string()` shall extract `aperture_value` as an unsigned 12-bit value spanning bytes 5–6 of the Cooke binary payload.
+- [x] **OPT-COOKE-003**: `fixed_data_from_string()` shall extract the firmware version string from character positions 61–65 of the Cooke fixed data string.
+- [ ] **OPT-COOKE-004**: If `lens_data_from_binary_string()` receives a payload shorter than the minimum required length, the system shall raise `ValueError` rather than producing incorrect values silently.

--- a/docs/specs/protocol-envelope-specs.md
+++ b/docs/specs/protocol-envelope-specs.md
@@ -1,0 +1,30 @@
+# Protocol Envelope Specs
+
+## Clip Model
+
+- [x] **PROTO-CORE-001**: The system shall synthesize `Clip` property accessors from `json_schema_extra` `clip_property` paths at class definition time, without hand-coded per-property accessor code.
+- [x] **PROTO-CORE-002**: `Clip.to_json()` shall serialize to a JSON-compatible dict excluding all fields set to their default values (compact wire format).
+- [x] **PROTO-CORE-003**: `Clip.append(other)` shall concatenate the dynamic tuple fields of `other` onto `self`, growing each per-frame tuple by one entry.
+- [x] **PROTO-CORE-004**: When a `Clip` is indexed with `clip[i]`, the system shall return a new single-frame `Clip` containing the data at frame index `i`.
+- [x] **PROTO-CORE-005**: `Clip.make_json_schema()` shall produce a self-contained JSON Schema document with all `$ref` pointers inlined.
+- [x] **PROTO-CORE-006**: The external schema generator shall strip Pydantic-internal wrapping layers (default, anyOf-for-None, tuple) from the published OpenTrackIO schema.
+- [x] **PROTO-CORE-007**: When `VersionedProtocol` is constructed with a `name` value other than `"OpenTrackIO"`, the system shall raise `ValueError`.
+- [x] **PROTO-CORE-008**: `guess_fps(fps)` shall convert approximate float FPS values to exact `Fraction` rationals for known broadcast frame rates (24, 25, 30, 60 and their NTSC drop-frame equivalents) within a 1% tolerance.
+- [x] **PROTO-CORE-009**: If `guess_fps(fps)` receives a non-integer, non-rational float that does not match any known frame rate within 1% tolerance, the system shall raise `ValueError`.
+- [x] **PROTO-CORE-010**: If `guess_fps(fps)` receives a value that is not a `numbers.Real`, the system shall raise `TypeError`.
+
+## Schema Compatibility
+
+- [x] **PROTO-SCHEMA-001**: The internal schema generator shall retain `clip_property` metadata in the schema (used for property accessor synthesis).
+- [x] **PROTO-SCHEMA-002**: The external schema generator shall strip `clip_property` metadata from the published schema.
+- [x] **PROTO-SCHEMA-003**: The schema generator shall resolve all JSON Schema `$ref` pointers via `jsonref` before returning the schema document.
+- [x] **PROTO-SCHEMA-004**: `CompatibleBaseModel` subclasses shall forbid extra fields during validation.
+- [x] **PROTO-SCHEMA-005**: `CompatibleBaseModel` subclasses shall validate field assignments after construction.
+
+## Examples
+
+- [x] **PROTO-EX-001**: The system shall provide a recommended static example `Clip` with minimal required fields populated.
+- [x] **PROTO-EX-002**: The system shall provide a complete static example `Clip` with all documented static fields populated.
+- [x] **PROTO-EX-003**: The system shall provide a recommended dynamic example `Clip` with minimal per-frame fields populated.
+- [x] **PROTO-EX-004**: The system shall provide a complete dynamic example `Clip` with all documented dynamic fields populated, including PTP synchronization.
+- [ ] **PROTO-EX-005**: When generating example JSON for schema validation, the system shall use a stable deterministic UUID rather than a random `uuid4()` to enable regression comparison without UUID normalization.

--- a/docs/specs/spatial-tracking-specs.md
+++ b/docs/specs/spatial-tracking-specs.md
@@ -1,0 +1,24 @@
+# Spatial Tracking Specs
+
+## Transform Types
+
+- [x] **TRACK-TYPES-001**: `Transform` shall hold `translation` (`Vector3`) and `rotation` (`Rotator3`) as required fields, with `scale` (`Vector3`) and `id` (string) as optional fields.
+- [x] **TRACK-TYPES-002**: The `Clip.transforms` field shall support multiple `Transform` objects per frame as a tuple, enabling named transforms (e.g., camera body and lens nodal point) within a single frame.
+- [x] **TRACK-TYPES-003**: `Vector3` shall represent a 3D point or displacement with nullable `x`, `y`, `z` float components in meters.
+- [x] **TRACK-TYPES-004**: `Rotator3` shall represent orientation with nullable `pan`, `tilt`, `roll` float components in degrees.
+- [x] **TRACK-TYPES-005**: `GlobalPosition` shall hold ENU (East-North-Up) local tangent plane coordinates (`E`, `N`, `U` in meters) and a geodetic origin (`lat0` in degrees, `lon0` in degrees, `h0` in meters).
+
+## Tracker Dynamic State
+
+- [x] **TRACK-DYN-001**: `Tracker` shall support per-frame `notes`, `recording`, `slate`, and `status` fields as optional tuples.
+
+## Mo-Sys F4 Protocol
+
+- [x] **TRACK-F4-001**: The F4 packet parser shall validate the packet checksum (XOR of all bytes with 0x40) before processing axis data, and reject packets with invalid checksums.
+- [x] **TRACK-F4-002**: The F4 packet parser shall map F4 axis IDs to corresponding OpenTrackIO `Clip` fields (pan/tilt/roll → rotation, x/y/z → translation, focus/iris/zoom → encoders, distortion coefficients, projection offset, f-number, focal length, focus distance, entrance pupil).
+- [x] **TRACK-F4-003**: The F4 packet parser shall generate a unique `uuid4()` for `sample_id` and `source_id` on each parsed frame.
+- [x] **TRACK-F4-004**: The F4 packet parser shall extract timecode from the packet status byte, with frame rate encoded as a 2-bit field supporting 24, 25, 30, and 30000/1001 fps.
+- [x] **TRACK-F4-005**: The MoSys reader `to_clip()` shall accumulate per-frame `Clip` objects using `Clip.append()`, building a multi-frame clip from a sequential F4 binary stream.
+- [x] **TRACK-F4-006**: The MoSys reader `to_clip()` shall read frames indefinitely from the F4 file when called with the default `frames=-1` argument, or up to `frames` frames when a positive count is specified.
+- [ ] **TRACK-F4-007**: The F4 packet parser focal length computation shall use a configurable sensor size parameter rather than the hardcoded 36×24mm full-frame assumption at `f4.py:287`.
+- [ ] **TRACK-F4-008**: `GlobalPosition` shall validate `lat0` to the range `[-90.0, 90.0]` degrees and `lon0` to the range `[-180.0, 180.0]` degrees.

--- a/docs/specs/temporal-synchronization-specs.md
+++ b/docs/specs/temporal-synchronization-specs.md
@@ -1,0 +1,33 @@
+# Temporal Synchronization Specs
+
+## Timecode
+
+- [x] **TSYNC-TC-001**: `Timecode.frames` shall be validated to be strictly less than the ceiling of the `frame_rate` rational value, preventing frame counts that exceed the format's capacity.
+- [x] **TSYNC-TC-002**: `Timecode.hours` shall be constrained to `[0, 23]`, `minutes` to `[0, 59]`, `seconds` to `[0, 59]`, and `frames` to `[0, 119]`.
+- [x] **TSYNC-TC-003**: `Timecode.frame_rate` shall be a `StrictlyPositiveRational` (both numerator and denominator strictly positive integers).
+- [x] **TSYNC-TC-004**: `Timecode.dropFrame` shall be an optional boolean flag; its absence does not imply non-drop-frame.
+
+## Timestamp
+
+- [x] **TSYNC-TS-001**: `Timestamp` shall store time as a pair of `seconds` (`NonNegative48BitInt`, max ≈ year 10889 from epoch) and `nanoseconds` (`NonNegativeInt`).
+- [ ] **TSYNC-TS-002**: `Timestamp.nanoseconds` shall be constrained to `[0, 999_999_999]` (values ≥ 1 second shall be rejected as invalid).
+
+## PTP Synchronization
+
+- [x] **TSYNC-PTP-001**: `SynchronizationPTP.leader_identity` shall match a MAC-address-like hex string with colon or dash separators (six two-hex-digit groups).
+- [x] **TSYNC-PTP-002**: `SynchronizationPTP.domain` shall be constrained to `[0, 127]`.
+- [x] **TSYNC-PTP-003**: `SynchronizationPTP.leader_accuracy` shall be constrained to `[0, 254]`.
+- [x] **TSYNC-PTP-004**: `SynchronizationPTP.mean_path_delay` shall represent one-way network delay in nanoseconds as a non-negative integer.
+- [x] **TSYNC-PTP-005**: `SynchronizationPTPPriorities` shall hold `priority1` and `priority2` each constrained to `[0, 255]`.
+
+## Synchronization
+
+- [x] **TSYNC-SYNC-001**: `Synchronization` shall carry `locked` (bool), `source` (`SynchronizationSourceEnum`), and `frequency` (`StrictlyPositiveRational`) as the core sync status fields.
+- [x] **TSYNC-SYNC-002**: `Synchronization.ptp` shall be present only when `synchronization.source` is `"ptp"`.
+- [x] **TSYNC-SYNC-003**: `SynchronizationOffsets` shall carry optional per-axis temporal calibration offsets for `translation`, `rotation`, and `lensEncoders` as floats.
+
+## Timing Container
+
+- [x] **TSYNC-TIMING-001**: `Timing.sample_rate` shall be a single `StrictlyPositiveRational` value for the whole clip (not a per-frame tuple).
+- [x] **TSYNC-TIMING-002**: When setting `Timing.sample_rate` from a tuple input (as produced by `Clip` accessors), the system shall extract element `[0]` and coerce it to `StrictlyPositiveRational`.
+- [x] **TSYNC-TIMING-003**: `Timing.mode`, `sample_timestamp`, `sequence_number`, `synchronization`, and `timecode` shall each be per-frame tuple fields on `Clip`.

--- a/src/main/python/camdkit/arri/reader.py
+++ b/src/main/python/camdkit/arri/reader.py
@@ -22,11 +22,13 @@ _CAMERA_FAMILY_PIXEL_PITCH_MAP = {
   ("ALEXALF", 4448) : Fraction(367000, 4448),
 }
 
+# @spec BRIDGE-ARRI-002
 def t_number_from_linear_iris_value(lin_value: int) -> typing.Optional[Fraction]:
   """Calculate t-number (regular iris values) from linear iris values
   """
   return math.pow(2, (lin_value - 1000)/1000/2)
 
+# @spec BRIDGE-IFACE-001, BRIDGE-ARRI-001, BRIDGE-ARRI-003
 def to_clip(csv_path: str) -> camdkit.model.Clip:
   """Read ARRI camera metadata into a `Clip`. `csv_path` is the path to a CSV
   file extracted using ARRI Meta Extract (AME)."""

--- a/src/main/python/camdkit/bmd/reader.py
+++ b/src/main/python/camdkit/bmd/reader.py
@@ -17,6 +17,7 @@ _FRAME_HEADING_RE = re.compile(r"^Frame (\d+) Metadata$")
 _METADATA_LINE_RE = re.compile(r"^([^:]+): (.+)$")
 
 
+# @spec BRIDGE-IFACE-001, BRIDGE-BMD-001, BRIDGE-BMD-002
 def to_clip(metadata_file: typing.IO) -> camdkit.model.Clip:
   """Read Blackmagic camera metadata into a `Clip`.
   `metadata_raw_sdk`: Output of the ExtractMetadata sample tool from the Blackmagic RAW SDK

--- a/src/main/python/camdkit/camera_types.py
+++ b/src/main/python/camdkit/camera_types.py
@@ -28,6 +28,7 @@ from camdkit.string_types import NonBlankUTF8String, UUIDURN
 # work, but for now it's a wish, not something for a to-do list.
 
 
+# @spec CAMID-CAM-002
 class PhysicalDimensions(CompatibleBaseModel):
     """Height and width of the active area of the camera sensor in millimeters
     """
@@ -41,6 +42,7 @@ class PhysicalDimensions(CompatibleBaseModel):
         super(PhysicalDimensions, self).__init__(width=width, height=height)
 
 
+# @spec CAMID-CAM-003
 class SenselDimensions(CompatibleBaseModel):
     """Photosite resolution of the active area of the camera sensor in pixels"""
     height: Annotated[int, Field(ge=0, le=MAX_INT_32)]
@@ -53,9 +55,11 @@ class SenselDimensions(CompatibleBaseModel):
         super(SenselDimensions, self).__init__(width=width, height=height)
 
 
+# @spec CAMID-CAM-004
 ShutterAngle = Annotated[float, Field(ge=0.0, le=360.0, strict=True)]
 
 
+# @spec CAMID-CAM-001, CAMID-CAM-005, CAMID-CAM-006
 class StaticCamera(CompatibleBaseModel):
     capture_frame_rate: Annotated[StrictlyPositiveRational | None,
       Field(alias="captureFrameRate",

--- a/src/main/python/camdkit/canon/reader.py
+++ b/src/main/python/camdkit/canon/reader.py
@@ -16,6 +16,7 @@ import camdkit.model
 def _read_float32_as_hex(float32_hex: str) -> float:
   return struct.unpack('>f', bytes.fromhex(float32_hex))[0]
 
+# @spec BRIDGE-IFACE-001, BRIDGE-CANON-001, BRIDGE-CANON-002, BRIDGE-CANON-003, BRIDGE-CANON-004
 def to_clip(static_csv: typing.IO, frames_csv: typing.IO) -> camdkit.model.Clip:
   """Read Canon camera metadata into a `Clip`.
   `static_csv`: Static camera metadata.

--- a/src/main/python/camdkit/clip.py
+++ b/src/main/python/camdkit/clip.py
@@ -209,6 +209,7 @@ class Clip(CompatibleBaseModel):
         # print(f"called setattr({cls}, {name}, {property(lambda s: 'foo', lambda s, v: None)}")
         # setattr(cls, name, property(lambda s: 'foo', lambda s, v: None))
 
+    # @spec PROTO-CORE-001
     @classmethod
     def setup_clip_properties(cls) -> type:
         def property_adder(property_name: str,
@@ -250,12 +251,14 @@ class Clip(CompatibleBaseModel):
         Clip.traverse_json_schema(Clip, full_schema, ('',), document_clip_property)
         return documentation
 
+    # @spec PROTO-CORE-005
     @classmethod
     def make_json_schema(cls, mode: JsonSchemaMode = 'serialization',
                          exclude_camdkit_internals: bool = True) -> JsonSchemaValue:
         result = CLIP_SCHEMA_PRELUDE | super(Clip, cls).make_json_schema(mode, exclude_camdkit_internals)
         return result
 
+    # @spec PROTO-CORE-003
     def append(self, other: Self) -> None:
         full_schema = Clip.make_json_schema(mode='validation', exclude_camdkit_internals=False)
 
@@ -274,6 +277,7 @@ class Clip(CompatibleBaseModel):
 
         Clip.traverse_json_schema(Clip, full_schema, ('',), appender)
 
+    # @spec PROTO-CORE-004
     def __getitem__(self, i) -> Self:
         full_schema = Clip.make_json_schema(mode='validation', exclude_camdkit_internals=False)
         result = Clip()
@@ -291,6 +295,7 @@ class Clip(CompatibleBaseModel):
         Clip.traverse_json_schema(Clip, full_schema, ('',), extractor)
         return result
 
+    # @spec PROTO-CORE-002
     def to_json(self, i: Optional[int] = None) -> Self:
         if i != None:
             single_frame_clip: Self =  self[i]

--- a/src/main/python/camdkit/compatibility.py
+++ b/src/main/python/camdkit/compatibility.py
@@ -246,6 +246,7 @@ class CompatibleSchemaGenerator(GenerateJsonSchema):
     def cleanup(self, schema: JsonSchemaValue) -> None:
         raise NotImplementedError()
 
+    # @spec PROTO-SCHEMA-003
     def generate(self, schema: JsonSchemaValue, mode='validation'):
         json_schema = super().generate(schema, mode=mode)
         json_schema = jsonref.replace_refs(json_schema, proxies=False, merge_props=True)
@@ -253,15 +254,18 @@ class CompatibleSchemaGenerator(GenerateJsonSchema):
         canonicalize_descriptions(json_schema)
         return json_schema
 
+# @spec PROTO-SCHEMA-001
 class InternalCompatibleSchemaGenerator(CompatibleSchemaGenerator):
     def cleanup(self, schema: JsonSchemaValue) -> None:
         scrub_excluded(schema, ALWAYS_EXCLUDED)
 
+# @spec PROTO-SCHEMA-002, PROTO-CORE-006
 class ExternalCompatibleSchemaGenerator(CompatibleSchemaGenerator):
     def cleanup(self, schema: JsonSchemaValue) -> None:
         scrub_excluded(schema, ALWAYS_EXCLUDED + EXCLUDED_CAMDKIT_INTERNALS)
 
 
+# @spec PROTO-SCHEMA-004, PROTO-SCHEMA-005
 # For compatibility with existing code
 class CompatibleBaseModel(BaseModel):
     """Base class for all camdkit parameters."""

--- a/src/main/python/camdkit/lens_types.py
+++ b/src/main/python/camdkit/lens_types.py
@@ -24,6 +24,7 @@ from camdkit.string_types import NonBlankUTF8String
 from camdkit.units import MILLIMETER, METER
 
 
+# @spec CAMID-LENS-001, CAMID-LENS-002, CAMID-LENS-003, CAMID-LENS-004
 class StaticLens(CompatibleBaseModel):
     distortion_overscan_max: Annotated[UnityOrGreaterFloat | None,
       Field(alias="distortionOverscanMax",
@@ -85,6 +86,7 @@ class StaticLens(CompatibleBaseModel):
     """List of free strings that describe the history of calibrations of the lens."""
 
 
+# @spec OPT-DIST-001, OPT-DIST-002, OPT-DIST-003, OPT-DIST-004
 class Distortion(CompatibleBaseModel):
     model: Annotated[NonBlankUTF8String | None, Field(default="Brown-Conrady D-U")]
 
@@ -119,17 +121,20 @@ class PlanarOffset(CompatibleBaseModel):
     def __init__(self, x: float, y: float):
         super(PlanarOffset, self).__init__(x=x, y=y)
 
+# @spec OPT-OFFSET-001
 class DistortionOffset(PlanarOffset):
 
     def __init__(self, x: float, y: float):
         super(DistortionOffset, self).__init__(x=x, y=y)
 
+# @spec OPT-OFFSET-001
 class ProjectionOffset(PlanarOffset):
 
     def __init__(self, x: float, y: float):
         super(ProjectionOffset, self).__init__(x=x, y=y)
 
 
+# @spec OPT-ENC-001, OPT-ENC-002
 class FizEncoders(CompatibleBaseModel):
     focus: NormalizedFloat | None = None
     iris: NormalizedFloat | None = None
@@ -143,6 +148,7 @@ class FizEncoders(CompatibleBaseModel):
             raise ValueError("FizEncoders requires at least one of focus or iris or zoom")
 
 
+# @spec OPT-ENC-003, OPT-ENC-004
 class RawFizEncoders(CompatibleBaseModel):
     focus: NonNegativeInt | None = None
     iris: NonNegativeInt | None = None
@@ -155,6 +161,7 @@ class RawFizEncoders(CompatibleBaseModel):
         if self.focus is None and self.iris is None and self.zoom is None:
             raise ValueError("RawFizEncoders requires at least one of focus or iris or zoom")
 
+# @spec OPT-FALLOFF-001
 class ExposureFalloff(CompatibleBaseModel):
     a1: float
     a2: float | None = None

--- a/src/main/python/camdkit/mosys/f4.py
+++ b/src/main/python/camdkit/mosys/f4.py
@@ -273,13 +273,14 @@ class F4PacketParser:
       frame.timing_mode = ("internal",)
       frame.timing_sequence_number = (self._frame_number,)
       syncEnabled = (self._packet.status & (1 << 5)) != 0
-      sync = Synchronization(
-        locked=syncEnabled,
-        present=syncEnabled,
-        source=SynchronizationSourceEnum.GENLOCK,
-        frequency=frequency
-      )
-      frame.timing_synchronization = (sync,)
+      if frequency is not None:
+        sync = Synchronization(
+          locked=syncEnabled,
+          present=syncEnabled,
+          source=SynchronizationSourceEnum.GENLOCK,
+          frequency=frequency
+        )
+        frame.timing_synchronization = (sync,)
       # In this case there is only one transform
       transform = Transform(translation=translation, rotation=rotation)
       transform.id = f'Camera {self._packet.camera_id}'

--- a/src/main/python/camdkit/mosys/f4.py
+++ b/src/main/python/camdkit/mosys/f4.py
@@ -95,6 +95,7 @@ class F4Packet:
   size: int = 0
   axis_block_list: list[F4AxisBlock] = []
 
+  # @spec TRACK-F4-001
   def initialise(self, buffer: bytes) -> bool:
     if len(buffer) == 0:
       return False
@@ -191,6 +192,7 @@ class F4PacketParser:
     self._initialised = True
     return True
        
+  # @spec TRACK-F4-002, TRACK-F4-003, TRACK-F4-004
   def get_tracking_frame(self) -> Clip:
     # Populates a Clip with a single frame of data of each parameter
     frame = Clip()

--- a/src/main/python/camdkit/mosys/reader.py
+++ b/src/main/python/camdkit/mosys/reader.py
@@ -18,6 +18,7 @@ def to_frame(data: bytes) -> Clip:
     frame = parser.get_tracking_frame()
   return success, frame, parser._packet.size
 
+# @spec BRIDGE-IFACE-001, TRACK-F4-005, TRACK-F4-006
 def to_clip(filename: str, frames: int = -1) -> Clip:
   """Read Mo-Sys F4 data into a Clip.
   `filename`: Filename of the f4 file.

--- a/src/main/python/camdkit/red/cooke.py
+++ b/src/main/python/camdkit/red/cooke.py
@@ -13,6 +13,7 @@ class CookeLensData:
   entrance_pupil_position: int
   aperture_value: int
 
+# @spec OPT-COOKE-001, OPT-COOKE-002
 def lens_data_from_binary_string(cooked_packed_bin_data: bytes) -> CookeLensData:
   sign = -1 if cooked_packed_bin_data[25] & 0b00100000 else 1
   entrance_pupil_position = sign * (((cooked_packed_bin_data[25] & 0b00001111) << 6) + (cooked_packed_bin_data[26] & 0b00111111))
@@ -23,5 +24,6 @@ def lens_data_from_binary_string(cooked_packed_bin_data: bytes) -> CookeLensData
 class CookeFixedData:
   firmware_version_number: str
 
+# @spec OPT-COOKE-003
 def fixed_data_from_string(cooked_fixed_data: str) -> CookeFixedData:
   return CookeFixedData(firmware_version_number=cooked_fixed_data[61:65])

--- a/src/main/python/camdkit/red/reader.py
+++ b/src/main/python/camdkit/red/reader.py
@@ -23,6 +23,7 @@ _LENS_NAME_PIXEL_PITCH_MAP = {
   "DRAGON": 5
 }
 
+# @spec BRIDGE-IFACE-001, BRIDGE-RED-001, BRIDGE-RED-002, BRIDGE-RED-003
 def to_clip(meta_3_file: typing.IO, meta_5_file: typing.IO) -> camdkit.model.Clip:
   """Read RED camera metadata into a `Clip`.
   `meta_3_file`: Static camera metadata. CSV file generated using REDline (`REDline --silent --i {camera_file_path} --printMeta 3`)

--- a/src/main/python/camdkit/timing_types.py
+++ b/src/main/python/camdkit/timing_types.py
@@ -62,6 +62,7 @@ class TimingMode(StrEnum):
     EXTERNAL = "external"
 
 
+# @spec TSYNC-TC-001, TSYNC-TC-002, TSYNC-TC-003, TSYNC-TC-004
 class Timecode(CompatibleBaseModel):
     """SMPTE timecode of the sample. Timecode is a standard for labeling
     individual frames of data in media systems and is useful for
@@ -86,12 +87,14 @@ class Timecode(CompatibleBaseModel):
     def coerce_frame_rate_to_strictly_positive_rational(cls, v):
         return rationalize_strictly_and_positively(v)
 
+    # @spec TSYNC-TC-001
     @model_validator(mode="after")
     def check_frames_allowed_by_format(self):
         if self.frames >= Fraction(self.frame_rate.num, self.frame_rate.denom).__ceil__():
             raise ValueError("The frame number must be less than the frame rate.")
         return self
 
+# @spec TSYNC-TS-001
 class Timestamp(CompatibleBaseModel):
     seconds: NonNegative48BitInt
     nanoseconds: NonNegativeInt
@@ -124,6 +127,7 @@ class SynchronizationOffsets(CompatibleBaseModel):
                                                      lensEncoders=lensEncoders)
 
 
+# @spec TSYNC-PTP-001, TSYNC-PTP-002, TSYNC-PTP-003, TSYNC-PTP-004, TSYNC-PTP-005
 class SynchronizationPTP(CompatibleBaseModel):
 
     profile: Annotated[PTPProfile, Field()]
@@ -177,6 +181,7 @@ class Synchronization(CompatibleBaseModel):
         return rationalize_strictly_and_positively(v)
 
 
+# @spec TSYNC-TIMING-001, TSYNC-TIMING-002, TSYNC-TIMING-003
 class Timing(CompatibleBaseModel):
     mode: Annotated[tuple[TimingMode, ...] | None,
       Field(json_schema_extra={"clip_property": "timing_mode",

--- a/src/main/python/camdkit/tracker_types.py
+++ b/src/main/python/camdkit/tracker_types.py
@@ -16,6 +16,7 @@ from camdkit.compatibility import (CompatibleBaseModel,
                                    NONBLANK_UTF8_MAX_1023_CHARS)
 
 
+# @spec CAMID-TRK-001
 class StaticTracker(CompatibleBaseModel):
     make: Annotated[NonBlankUTF8String | None,
       Field(json_schema_extra={"clip_property": "tracker_make",
@@ -40,6 +41,7 @@ class StaticTracker(CompatibleBaseModel):
     """Non-blank string identifying tracking device firmware version"""
 
 
+# @spec TRACK-DYN-001
 class Tracker(CompatibleBaseModel):
     notes: Annotated[tuple[NonBlankUTF8String, ...] | None,
       Field(json_schema_extra={"clip_property": "tracker_notes",
@@ -62,6 +64,7 @@ class Tracker(CompatibleBaseModel):
     """Non-blank string describing status of tracking system"""
 
 
+# @spec TRACK-TYPES-005
 class GlobalPosition(CompatibleBaseModel):
     """Global ENU and geodetic coördinates
     Reference:. https://en.wikipedia.org/wiki/Local_tangent_plane_coordinates

--- a/src/main/python/camdkit/transform_types.py
+++ b/src/main/python/camdkit/transform_types.py
@@ -14,6 +14,7 @@ from camdkit.compatibility import CompatibleBaseModel
 from camdkit.string_types import NonBlankUTF8String
 from camdkit.units import DEGREE, METER
 
+# @spec TRACK-TYPES-003
 class Vector3(CompatibleBaseModel):
     x: Annotated[float | None, Field()] = None
     y: Annotated[float | None, Field()] = None
@@ -26,6 +27,7 @@ class Vector3(CompatibleBaseModel):
         super(Vector3, self).__init__(x=x, y=y, z=z)
 
 
+# @spec TRACK-TYPES-004
 class Rotator3(CompatibleBaseModel):
     pan: Annotated[float | None, Field()] = None
     tilt: Annotated[float | None, Field()] = None
@@ -38,6 +40,7 @@ class Rotator3(CompatibleBaseModel):
         super(Rotator3, self).__init__(pan=pan, tilt=tilt, roll=roll)
 
 
+# @spec TRACK-TYPES-001, TRACK-TYPES-002
 class Transform(CompatibleBaseModel):
     translation: Annotated[Vector3, Field(json_schema_extra={"units": METER})]
     rotation: Annotated[Rotator3, Field(json_schema_extra={"units": DEGREE})]

--- a/src/main/python/camdkit/utils.py
+++ b/src/main/python/camdkit/utils.py
@@ -12,6 +12,7 @@ import numbers
 _WELL_KNOWN_FRACTIONAL_FPS = set([Fraction(24000, 1001), Fraction(30000, 1001), Fraction(60000, 1001), Fraction(120000, 1001)])
 _FPS_THRESHOLD = 0.01
 
+# @spec PROTO-CORE-008, PROTO-CORE-009, PROTO-CORE-010
 def guess_fps(fps: numbers.Real) -> Fraction:
   """Heuristically determines an exact fps value from an approximate one using
   well-known fps values."""

--- a/src/main/python/camdkit/venice/reader.py
+++ b/src/main/python/camdkit/venice/reader.py
@@ -133,6 +133,7 @@ def t_number_from_frac_stop(frac_stop_str: str) -> typing.Optional[float]:
 def int_or_none(value: typing.Optional[str]) -> typing.Optional[int]:
   return int(value) if value is not None else None
 
+# @spec BRIDGE-IFACE-001, BRIDGE-VENICE-001, BRIDGE-VENICE-002, BRIDGE-VENICE-003, BRIDGE-VENICE-004, BRIDGE-VENICE-005
 def to_clip(static_file: typing.IO, dynamic_file: typing.IO) -> camdkit.model.Clip:
   """Read Sony Venice camera metadata into a `Clip`.
   `static_file`: Static camera metadata. XML file.

--- a/src/main/python/camdkit/versioning_types.py
+++ b/src/main/python/camdkit/versioning_types.py
@@ -21,6 +21,7 @@ OPENTRACKIO_PROTOCOL_VERSION = (1, 0, 1)
 
 VersionComponent = Annotated[int, Field(ge=0, le=9)]
 
+# @spec PROTO-CORE-007
 class VersionedProtocol(CompatibleBaseModel):
     name: NonBlankUTF8String
     version: Annotated[tuple[VersionComponent, ...], Field(min_length=3, max_length=3)]

--- a/src/test/python/property/generators.py
+++ b/src/test/python/property/generators.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the SMTPE RIS OSVP Metadata Project
+
+"""Hypothesis strategies for camdkit types, organized bottom-up by layer."""
+
+import math
+import sys
+from fractions import Fraction
+
+from hypothesis import strategies as st, assume
+
+from camdkit.numeric_types import (
+    MAX_INT_8, MAX_UINT_8, MAX_UINT_32, MAX_UINT_48, MIN_INT_32, MAX_INT_32,
+    Rational, StrictlyPositiveRational,
+)
+from camdkit.string_types import UUID_URN_PATTERN
+from camdkit.timing_types import (
+    PTPProfile, PTPLeaderTimeSource, SynchronizationSource, TimingMode,
+    Timestamp, Timecode, SynchronizationPTP, SynchronizationPTPPriorities,
+    SynchronizationOffsets, Synchronization,
+)
+from camdkit.transform_types import Vector3, Rotator3, Transform
+from camdkit.lens_types import (
+    Distortion, DistortionOffset, ProjectionOffset,
+    FizEncoders, RawFizEncoders, ExposureFalloff,
+)
+from camdkit.camera_types import PhysicalDimensions, SenselDimensions
+from camdkit.tracker_types import GlobalPosition
+from camdkit.clip import Clip
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: Primitive strategies
+# ---------------------------------------------------------------------------
+
+non_negative_8bit_ints = st.integers(min_value=0, max_value=MAX_INT_8)
+non_negative_ints = st.integers(min_value=0, max_value=MAX_UINT_32)
+non_negative_48bit_ints = st.integers(min_value=0, max_value=MAX_UINT_48)
+strictly_positive_ints = st.integers(min_value=1, max_value=MAX_UINT_32)
+sensel_ints = st.integers(min_value=0, max_value=MAX_INT_32)
+uint8_ints = st.integers(min_value=0, max_value=MAX_UINT_8)
+
+non_negative_floats = st.floats(min_value=0.0, allow_nan=False, allow_infinity=False)
+strictly_positive_floats = st.floats(
+    min_value=sys.float_info.epsilon, allow_nan=False, allow_infinity=False
+)
+normalized_floats = st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
+unity_or_greater_floats = st.floats(min_value=1.0, allow_nan=False, allow_infinity=False)
+reals = st.floats(allow_nan=False, allow_infinity=False)
+shutter_angle_floats = st.floats(min_value=0.0, max_value=360.0, allow_nan=False, allow_infinity=False)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: Rational types
+# ---------------------------------------------------------------------------
+
+@st.composite
+def rationals(draw):
+    num = draw(st.integers(min_value=MIN_INT_32, max_value=MAX_INT_32))
+    denom = draw(st.integers(min_value=1, max_value=MAX_UINT_32))
+    return Rational(num, denom)
+
+
+@st.composite
+def strictly_positive_rationals(draw):
+    num = draw(st.integers(min_value=1, max_value=MAX_INT_32))
+    denom = draw(st.integers(min_value=1, max_value=MAX_UINT_32))
+    return StrictlyPositiveRational(num, denom)
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: String types and geometric types
+# ---------------------------------------------------------------------------
+
+@st.composite
+def non_blank_utf8_strings(draw):
+    return draw(st.text(
+        min_size=1, max_size=50,
+        alphabet=st.characters(blacklist_categories=('Cs',))
+    ))
+
+
+uuid_urns = st.from_regex(UUID_URN_PATTERN, fullmatch=True)
+
+# MAC address in colon-separated form, always valid per PTP_LEADER_PATTERN
+ptp_leader_identities = st.builds(
+    lambda octets: ':'.join(octets),
+    octets=st.lists(
+        st.integers(min_value=0, max_value=255).map(lambda x: f"{x:02x}"),
+        min_size=6, max_size=6,
+    )
+)
+
+
+@st.composite
+def vector3s(draw):
+    return Vector3(draw(reals), draw(reals), draw(reals))
+
+
+@st.composite
+def rotator3s(draw):
+    return Rotator3(draw(reals), draw(reals), draw(reals))
+
+
+@st.composite
+def transforms(draw):
+    t = Transform(translation=draw(vector3s()), rotation=draw(rotator3s()))
+    if draw(st.booleans()):
+        t.scale = draw(vector3s())
+    if draw(st.booleans()):
+        t.id = draw(non_blank_utf8_strings())
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: Camera/sensor and lens types
+# ---------------------------------------------------------------------------
+
+@st.composite
+def physical_dimensions(draw):
+    return PhysicalDimensions(
+        width=draw(non_negative_floats),
+        height=draw(non_negative_floats),
+    )
+
+
+@st.composite
+def sensel_dimensions(draw):
+    return SenselDimensions(
+        width=draw(sensel_ints),
+        height=draw(sensel_ints),
+    )
+
+
+@st.composite
+def global_positions(draw):
+    return GlobalPosition(
+        E=draw(reals), N=draw(reals), U=draw(reals),
+        lat0=draw(reals), lon0=draw(reals), h0=draw(reals),
+    )
+
+
+@st.composite
+def distortions(draw):
+    radial = tuple(draw(st.lists(reals, min_size=1, max_size=6)))
+    tangential = draw(st.one_of(
+        st.none(),
+        st.lists(reals, min_size=1, max_size=4).map(tuple),
+    ))
+    # model=None is excluded by exclude_none but the default "Brown-Conrady D-U"
+    # is restored on deserialization, breaking the roundtrip. Only generate non-None.
+    model_name = draw(st.one_of(
+        st.just("Brown-Conrady D-U"),
+        st.just("Brown-Conrady U-D"),
+    ))
+    overscan = draw(st.one_of(st.none(), unity_or_greater_floats))
+    return Distortion(model=model_name, radial=radial, tangential=tangential, overscan=overscan)
+
+
+@st.composite
+def distortion_offsets(draw):
+    return DistortionOffset(draw(reals), draw(reals))
+
+
+@st.composite
+def projection_offsets(draw):
+    return ProjectionOffset(draw(reals), draw(reals))
+
+
+@st.composite
+def fiz_encoders(draw):
+    focus = draw(st.one_of(st.none(), normalized_floats))
+    iris = draw(st.one_of(st.none(), normalized_floats))
+    zoom = draw(st.one_of(st.none(), normalized_floats))
+    if focus is None and iris is None and zoom is None:
+        target = draw(st.sampled_from(['focus', 'iris', 'zoom']))
+        val = draw(normalized_floats)
+        if target == 'focus':
+            focus = val
+        elif target == 'iris':
+            iris = val
+        else:
+            zoom = val
+    return FizEncoders(focus=focus, iris=iris, zoom=zoom)
+
+
+@st.composite
+def raw_fiz_encoders(draw):
+    focus = draw(st.one_of(st.none(), non_negative_ints))
+    iris = draw(st.one_of(st.none(), non_negative_ints))
+    zoom = draw(st.one_of(st.none(), non_negative_ints))
+    if focus is None and iris is None and zoom is None:
+        target = draw(st.sampled_from(['focus', 'iris', 'zoom']))
+        val = draw(non_negative_ints)
+        if target == 'focus':
+            focus = val
+        elif target == 'iris':
+            iris = val
+        else:
+            zoom = val
+    return RawFizEncoders(focus=focus, iris=iris, zoom=zoom)
+
+
+@st.composite
+def exposure_falloffs(draw):
+    return ExposureFalloff(
+        a1=draw(reals),
+        a2=draw(st.one_of(st.none(), reals)),
+        a3=draw(st.one_of(st.none(), reals)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 5: Timing types
+# ---------------------------------------------------------------------------
+
+@st.composite
+def timestamps(draw):
+    return Timestamp(draw(non_negative_48bit_ints), draw(non_negative_ints))
+
+
+@st.composite
+def timecodes(draw):
+    frame_rate = draw(strictly_positive_rationals())
+    ceil_rate = math.ceil(Fraction(frame_rate.num, frame_rate.denom))
+    max_frames = min(ceil_rate - 1, 119)
+    assume(max_frames >= 0)
+    return Timecode(
+        hours=draw(st.integers(min_value=0, max_value=23)),
+        minutes=draw(st.integers(min_value=0, max_value=59)),
+        seconds=draw(st.integers(min_value=0, max_value=59)),
+        frames=draw(st.integers(min_value=0, max_value=max_frames)),
+        frame_rate=frame_rate,
+        sub_frame=draw(non_negative_ints),
+        dropFrame=draw(st.booleans()),
+    )
+
+
+@st.composite
+def synchronization_ptp_priorities(draw):
+    return SynchronizationPTPPriorities(draw(uint8_ints), draw(uint8_ints))
+
+
+@st.composite
+def synchronization_ptps(draw):
+    return SynchronizationPTP(
+        profile=draw(st.sampled_from(PTPProfile)),
+        domain=draw(non_negative_8bit_ints),
+        leader_identity=draw(ptp_leader_identities),
+        leader_priorities=draw(synchronization_ptp_priorities()),
+        leader_accuracy=draw(non_negative_floats),
+        leader_time_source=draw(st.one_of(st.none(), st.sampled_from(PTPLeaderTimeSource))),
+        mean_path_delay=draw(non_negative_floats),
+        vlan=draw(st.one_of(st.none(), non_negative_ints)),
+    )
+
+
+@st.composite
+def synchronization_offsets(draw):
+    return SynchronizationOffsets(
+        translation=draw(reals),
+        rotation=draw(reals),
+        lensEncoders=draw(reals),
+    )
+
+
+@st.composite
+def synchronizations(draw):
+    return Synchronization(
+        locked=draw(st.booleans()),
+        source=draw(st.sampled_from(SynchronizationSource)),
+        frequency=draw(st.one_of(st.none(), strictly_positive_rationals())),
+        offsets=draw(st.one_of(st.none(), synchronization_offsets())),
+        present=draw(st.one_of(st.none(), st.booleans())),
+        ptp=draw(st.one_of(st.none(), synchronization_ptps())),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 6: Clip
+# ---------------------------------------------------------------------------
+
+def _tuple_of(strategy, n):
+    """Draw a tuple of n elements from strategy."""
+    return st.tuples(*[strategy] * n)
+
+
+@st.composite
+def clips(draw):
+    clip = Clip()
+
+    # Static: global
+    if draw(st.booleans()):
+        clip.duration = draw(strictly_positive_rationals())
+
+    # Static: camera
+    if draw(st.booleans()):
+        clip.capture_frame_rate = draw(strictly_positive_rationals())
+    if draw(st.booleans()):
+        clip.anamorphic_squeeze = draw(strictly_positive_rationals())
+    if draw(st.booleans()):
+        clip.active_sensor_physical_dimensions = draw(physical_dimensions())
+    if draw(st.booleans()):
+        clip.active_sensor_resolution = draw(sensel_dimensions())
+    if draw(st.booleans()):
+        clip.camera_make = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.camera_model = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.camera_serial_number = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.camera_firmware = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.camera_label = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.iso = draw(strictly_positive_ints)
+    if draw(st.booleans()):
+        clip.fdl_link = draw(uuid_urns)
+    if draw(st.booleans()):
+        clip.shutter_angle = draw(shutter_angle_floats)
+
+    # Static: lens
+    if draw(st.booleans()):
+        clip.lens_make = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.lens_model = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.lens_serial_number = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.lens_firmware = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.lens_nominal_focal_length = draw(strictly_positive_floats)
+    if draw(st.booleans()):
+        clip.lens_distortion_overscan_max = draw(unity_or_greater_floats)
+    if draw(st.booleans()):
+        clip.lens_undistortion_overscan_max = draw(unity_or_greater_floats)
+
+    # Static: tracker
+    if draw(st.booleans()):
+        clip.tracker_make = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.tracker_model = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.tracker_serial_number = draw(non_blank_utf8_strings())
+    if draw(st.booleans()):
+        clip.tracker_firmware = draw(non_blank_utf8_strings())
+
+    # Dynamic fields: all tuples share the same length n
+    n = draw(st.integers(min_value=1, max_value=3))
+
+    # Dynamic: lens
+    if draw(st.booleans()):
+        clip.lens_t_number = draw(_tuple_of(strictly_positive_floats, n))
+    if draw(st.booleans()):
+        clip.lens_f_number = draw(_tuple_of(strictly_positive_floats, n))
+    if draw(st.booleans()):
+        clip.lens_pinhole_focal_length = draw(_tuple_of(strictly_positive_floats, n))
+    if draw(st.booleans()):
+        clip.lens_focus_distance = draw(_tuple_of(strictly_positive_floats, n))
+    if draw(st.booleans()):
+        clip.lens_entrance_pupil_offset = draw(_tuple_of(reals, n))
+    if draw(st.booleans()):
+        clip.lens_encoders = draw(_tuple_of(fiz_encoders(), n))
+    if draw(st.booleans()):
+        clip.lens_raw_encoders = draw(_tuple_of(raw_fiz_encoders(), n))
+    if draw(st.booleans()):
+        clip.lens_exposure_falloff = draw(_tuple_of(exposure_falloffs(), n))
+    if draw(st.booleans()):
+        one_frame_distortions = st.lists(distortions(), min_size=1).map(tuple)
+        clip.lens_distortions = draw(_tuple_of(one_frame_distortions, n))
+    if draw(st.booleans()):
+        clip.lens_distortion_offset = draw(_tuple_of(distortion_offsets(), n))
+    if draw(st.booleans()):
+        clip.lens_projection_offset = draw(_tuple_of(projection_offsets(), n))
+
+    # Dynamic: timing
+    if draw(st.booleans()):
+        clip.timing_mode = draw(_tuple_of(st.sampled_from(TimingMode), n))
+    if draw(st.booleans()):
+        clip.timing_sample_timestamp = draw(_tuple_of(timestamps(), n))
+    if draw(st.booleans()):
+        clip.timing_recorded_timestamp = draw(_tuple_of(timestamps(), n))
+    if draw(st.booleans()):
+        clip.timing_sequence_number = draw(_tuple_of(non_negative_ints, n))
+    if draw(st.booleans()):
+        clip.timing_sample_rate = draw(_tuple_of(strictly_positive_rationals(), n))
+    if draw(st.booleans()):
+        clip.timing_timecode = draw(_tuple_of(timecodes(), n))
+    if draw(st.booleans()):
+        clip.timing_synchronization = draw(_tuple_of(synchronizations(), n))
+
+    # Dynamic: tracker
+    if draw(st.booleans()):
+        clip.tracker_status = draw(_tuple_of(non_blank_utf8_strings(), n))
+    if draw(st.booleans()):
+        clip.tracker_recording = draw(_tuple_of(st.booleans(), n))
+    if draw(st.booleans()):
+        clip.tracker_slate = draw(_tuple_of(non_blank_utf8_strings(), n))
+    if draw(st.booleans()):
+        clip.tracker_notes = draw(_tuple_of(non_blank_utf8_strings(), n))
+
+    # Dynamic: global
+    if draw(st.booleans()):
+        clip.sample_id = draw(_tuple_of(uuid_urns, n))
+    if draw(st.booleans()):
+        clip.source_id = draw(_tuple_of(uuid_urns, n))
+    if draw(st.booleans()):
+        clip.source_number = draw(_tuple_of(non_negative_ints, n))
+    if draw(st.booleans()):
+        clip.related_sample_ids = draw(
+            _tuple_of(st.lists(uuid_urns, min_size=1).map(tuple), n)
+        )
+    if draw(st.booleans()):
+        clip.global_stage = draw(_tuple_of(global_positions(), n))
+    if draw(st.booleans()):
+        one_frame_transforms = st.lists(transforms(), min_size=1).map(tuple)
+        clip.transforms = draw(_tuple_of(one_frame_transforms, n))
+
+    return clip

--- a/src/test/python/property/test_json_roundtrip.py
+++ b/src/test/python/property/test_json_roundtrip.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the SMTPE RIS OSVP Metadata Project
+
+"""Property tests: JSON roundtrip for all camdkit model types."""
+
+import sys
+import unittest
+
+from hypothesis import given, settings, HealthCheck
+
+from camdkit.numeric_types import (
+    MAX_INT_8, MAX_INT_32, MAX_UINT_32, MIN_INT_32,
+    Rational, StrictlyPositiveRational,
+)
+from camdkit.transform_types import Vector3, Rotator3, Transform
+from camdkit.lens_types import Distortion, FizEncoders, RawFizEncoders, ExposureFalloff
+from camdkit.timing_types import (
+    Timestamp, Timecode, Synchronization, SynchronizationSource,
+    SynchronizationPTP, SynchronizationPTPPriorities, PTPProfile,
+)
+from camdkit.clip import Clip
+
+from property.generators import (
+    rationals, strictly_positive_rationals,
+    vector3s, rotator3s, transforms,
+    distortions, fiz_encoders, raw_fiz_encoders, exposure_falloffs,
+    timestamps, timecodes, synchronization_ptps, synchronizations,
+    clips,
+    non_negative_8bit_ints, strictly_positive_floats, unity_or_greater_floats,
+    ptp_leader_identities, synchronization_ptp_priorities, non_negative_floats,
+    non_negative_ints,
+)
+
+_SUPPRESS = [HealthCheck.too_slow, HealthCheck.filter_too_much]
+
+
+class RationalRoundtripTests(unittest.TestCase):
+
+    @given(r=rationals())
+    def test_rational_roundtrip(self, r):
+        recovered = Rational.from_json(Rational.to_json(r))
+        self.assertEqual(r, recovered)
+
+    @given(r=strictly_positive_rationals())
+    def test_strictly_positive_rational_roundtrip(self, r):
+        recovered = StrictlyPositiveRational.from_json(
+            StrictlyPositiveRational.to_json(r)
+        )
+        self.assertEqual(r, recovered)
+
+    def test_rational_max_values(self):
+        r = Rational(MAX_INT_32, MAX_UINT_32)
+        self.assertEqual(r, Rational.from_json(Rational.to_json(r)))
+
+    def test_rational_min_numerator(self):
+        r = Rational(MIN_INT_32, 1)
+        self.assertEqual(r, Rational.from_json(Rational.to_json(r)))
+
+    def test_strictly_positive_rational_max(self):
+        r = StrictlyPositiveRational(MAX_INT_32, MAX_UINT_32)
+        self.assertEqual(r, StrictlyPositiveRational.from_json(
+            StrictlyPositiveRational.to_json(r)
+        ))
+
+
+class GeometricTypeRoundtripTests(unittest.TestCase):
+
+    @given(v=vector3s())
+    def test_vector3_roundtrip(self, v):
+        recovered = Vector3.from_json(Vector3.to_json(v))
+        self.assertEqual(v, recovered)
+
+    @given(r=rotator3s())
+    def test_rotator3_roundtrip(self, r):
+        recovered = Rotator3.from_json(Rotator3.to_json(r))
+        self.assertEqual(r, recovered)
+
+    @given(t=transforms())
+    def test_transform_roundtrip(self, t):
+        recovered = Transform.from_json(Transform.to_json(t))
+        self.assertEqual(t, recovered)
+
+
+class LensTypeRoundtripTests(unittest.TestCase):
+
+    @given(d=distortions())
+    def test_distortion_roundtrip(self, d):
+        recovered = Distortion.from_json(Distortion.to_json(d))
+        self.assertEqual(d, recovered)
+
+    @given(f=fiz_encoders())
+    def test_fiz_encoders_roundtrip(self, f):
+        recovered = FizEncoders.from_json(FizEncoders.to_json(f))
+        self.assertEqual(f, recovered)
+
+    @given(r=raw_fiz_encoders())
+    def test_raw_fiz_encoders_roundtrip(self, r):
+        recovered = RawFizEncoders.from_json(RawFizEncoders.to_json(r))
+        self.assertEqual(r, recovered)
+
+    @given(e=exposure_falloffs())
+    def test_exposure_falloff_roundtrip(self, e):
+        recovered = ExposureFalloff.from_json(ExposureFalloff.to_json(e))
+        self.assertEqual(e, recovered)
+
+
+class TimingTypeRoundtripTests(unittest.TestCase):
+
+    @given(ts=timestamps())
+    def test_timestamp_roundtrip(self, ts):
+        recovered = Timestamp.from_json(Timestamp.to_json(ts))
+        self.assertEqual(ts, recovered)
+
+    @given(tc=timecodes())
+    @settings(suppress_health_check=_SUPPRESS)
+    def test_timecode_roundtrip(self, tc):
+        recovered = Timecode.from_json(Timecode.to_json(tc))
+        self.assertEqual(tc, recovered)
+
+    @given(s=synchronizations())
+    @settings(suppress_health_check=_SUPPRESS)
+    def test_synchronization_roundtrip(self, s):
+        recovered = Synchronization.from_json(Synchronization.to_json(s))
+        self.assertEqual(s, recovered)
+
+    def test_ptp_domain_lower_bound(self):
+        ptp = SynchronizationPTP(
+            profile=PTPProfile.SMPTE_2059_2_2021,
+            domain=0,
+            leader_identity="00:11:22:33:44:55",
+            leader_priorities=SynchronizationPTPPriorities(1, 2),
+            leader_accuracy=0.0,
+            mean_path_delay=0.0,
+        )
+        recovered = SynchronizationPTP.from_json(SynchronizationPTP.to_json(ptp))
+        self.assertEqual(ptp, recovered)
+
+    def test_ptp_domain_upper_bound(self):
+        ptp = SynchronizationPTP(
+            profile=PTPProfile.SMPTE_2059_2_2021,
+            domain=MAX_INT_8,  # 127
+            leader_identity="ff:ff:ff:ff:ff:ff",
+            leader_priorities=SynchronizationPTPPriorities(255, 255),
+            leader_accuracy=0.0,
+            mean_path_delay=0.0,
+        )
+        recovered = SynchronizationPTP.from_json(SynchronizationPTP.to_json(ptp))
+        self.assertEqual(ptp, recovered)
+
+
+class ClipRoundtripTests(unittest.TestCase):
+
+    @given(clip=clips())
+    @settings(max_examples=75, suppress_health_check=_SUPPRESS)
+    def test_clip_roundtrip(self, clip):
+        json_data = Clip.to_json(clip)
+        recovered = Clip.from_json(json_data)
+        self.assertEqual(clip, recovered)
+
+    def test_clip_roundtrip_empty(self):
+        clip = Clip()
+        self.assertEqual(clip, Clip.from_json(Clip.to_json(clip)))
+
+    def test_focus_distance_large_value(self):
+        """Boundary: focus distance at float max (open issue: infinity handling)."""
+        clip = Clip()
+        clip.lens_focus_distance = (sys.float_info.max,)
+        recovered = Clip.from_json(Clip.to_json(clip))
+        self.assertEqual(clip, recovered)
+
+    def test_multiple_distortion_objects_per_frame(self):
+        """Boundary: multiple Distortion objects in a single frame (open issue)."""
+        clip = Clip()
+        d1 = Distortion(model="Brown-Conrady D-U", radial=(0.1, 0.2, 0.3))
+        d2 = Distortion(model="Brown-Conrady U-D", radial=(-0.1, -0.2))
+        clip.lens_distortions = ((d1, d2),)
+        recovered = Clip.from_json(Clip.to_json(clip))
+        self.assertEqual(clip, recovered)
+
+    def test_zoom_lens_nominal_focal_length_absent(self):
+        """Boundary: zoom lens with nominalFocalLength explicitly absent (open issue)."""
+        clip = Clip()
+        clip.lens_make = "Zeiss"
+        clip.lens_model = "CZ.2 70-200"
+        json_data = Clip.to_json(clip)
+        # Confirm the field is absent from the serialized JSON, not just unset in Python
+        self.assertNotIn("nominalFocalLength", json_data.get("static", {}).get("lens", {}))
+        recovered = Clip.from_json(json_data)
+        self.assertEqual(clip, recovered)
+
+    def test_ptp_domain_boundaries_in_clip(self):
+        """Boundary: PTP domain at 0 and 127."""
+        for domain in (0, MAX_INT_8):
+            clip = Clip()
+            sync = Synchronization(
+                locked=True,
+                source=SynchronizationSource.PTP,
+                ptp=SynchronizationPTP(
+                    profile=PTPProfile.SMPTE_2059_2_2021,
+                    domain=domain,
+                    leader_identity="aa:bb:cc:dd:ee:ff",
+                    leader_priorities=SynchronizationPTPPriorities(1, 1),
+                    leader_accuracy=0.0,
+                    mean_path_delay=0.0,
+                ),
+            )
+            clip.timing_synchronization = (sync,)
+            recovered = Clip.from_json(Clip.to_json(clip))
+            self.assertEqual(clip, recovered)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/python/property/test_metamorphic.py
+++ b/src/test/python/property/test_metamorphic.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the SMTPE RIS OSVP Metadata Project
+
+"""Metamorphic property tests for camdkit.
+
+Metamorphic tests verify relationships between inputs and outputs rather than
+exact values. They catch classes of bugs that roundtrip tests miss — in
+particular, bugs where the code is consistent with itself but wrong about the
+spec.
+
+  Key order independence:
+    from_json(shuffle(to_json(x))) == from_json(to_json(x))
+
+  Default exclusion (exclude_defaults=True in the serializer):
+    to_json drops fields whose value equals their declared default
+
+  None exclusion (exclude_none=True):
+    to_json never emits explicit null; the output is always fully concrete
+
+  Optional-field neutrality:
+    setting an optional field to None produces the same JSON as leaving it unset
+
+  Extra-field tolerance:
+    from_json silently ignores unrecognized keys (extra='ignore')
+
+  Dynamic field length gap [documented]:
+    a clip with mismatched per-sample field lengths is accepted without error
+
+  Rational non-normalization [documented]:
+    Rational(2, 4) != Rational(1, 2) — camdkit compares structurally, not semantically;
+    consumers must normalize before comparing
+
+Tests marked [gap] document invariants the spec mandates but camdkit does not enforce.
+"""
+
+import unittest
+
+from hypothesis import given, settings, HealthCheck
+from hypothesis import strategies as st
+
+from camdkit.numeric_types import Rational, StrictlyPositiveRational
+from camdkit.timing_types import Timecode, TimingMode
+from camdkit.clip import Clip
+
+from property.generators import clips, timecodes, rationals
+
+_SUPPRESS = [HealthCheck.too_slow, HealthCheck.filter_too_much]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reverse_keys(obj):
+    """Recursively reverse the insertion order of all dict keys.
+
+    Array order is not changed — frame 0 must remain frame 0.
+    """
+    if isinstance(obj, dict):
+        return {k: _reverse_keys(v) for k, v in reversed(list(obj.items()))}
+    if isinstance(obj, list):
+        return [_reverse_keys(v) for v in obj]
+    return obj
+
+
+def _has_none(obj) -> bool:
+    """Return True if any value at any depth in a JSON-like structure is None."""
+    if obj is None:
+        return True
+    if isinstance(obj, dict):
+        return any(_has_none(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_has_none(v) for v in obj)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Key order independence
+# ---------------------------------------------------------------------------
+
+class KeyOrderTests(unittest.TestCase):
+
+    @given(clip=clips())
+    @settings(max_examples=75, suppress_health_check=_SUPPRESS)
+    def test_reversed_json_keys_give_same_clip(self, clip):
+        """Reversing all dict key orderings in JSON does not change the decoded clip.
+
+        Non-vacuous: tests that from_json is order-insensitive at every nesting level.
+        A parser that depended on key order (e.g. a positional dict reader) would fail.
+        """
+        json_data = Clip.to_json(clip)
+        reversed_json = _reverse_keys(json_data)
+        self.assertEqual(Clip.from_json(json_data), Clip.from_json(reversed_json))
+
+    def test_reversed_keys_on_multi_section_clip(self):
+        """Key reversal on a clip with multiple top-level sections (static, lens, timing)."""
+        clip = Clip()
+        clip.lens_make = "Zeiss"
+        clip.camera_make = "ARRI"
+        clip.lens_nominal_focal_length = 35.0
+        clip.timing_sequence_number = (0, 1, 2)
+        json_data = Clip.to_json(clip)
+        self.assertGreater(len(json_data), 1,
+            "Clip must have multiple top-level keys for this test to be non-trivial")
+        self.assertEqual(Clip.from_json(json_data), Clip.from_json(_reverse_keys(json_data)))
+
+
+# ---------------------------------------------------------------------------
+# Default exclusion
+# ---------------------------------------------------------------------------
+
+class DefaultExclusionTests(unittest.TestCase):
+    """Verify that exclude_defaults=True correctly suppresses known default values."""
+
+    def test_sub_frame_zero_excluded_from_timecode_json(self):
+        """Timecode.sub_frame=0 (the default) must not appear in serialized JSON.
+
+        Non-vacuous: if exclude_defaults was not applied, subFrame would appear in
+        every Timecode object even when it carries no information.
+        """
+        tc = Timecode(
+            hours=1, minutes=30, seconds=45, frames=12,
+            frame_rate=StrictlyPositiveRational(24, 1),
+            sub_frame=0,
+        )
+        json_data = Timecode.to_json(tc)
+        self.assertNotIn("subFrame", json_data,
+            "subFrame=0 (the default) should be excluded by exclude_defaults=True")
+
+    def test_drop_frame_false_excluded_from_timecode_json(self):
+        """Timecode.dropFrame=False (the default) must not appear in serialized JSON."""
+        tc = Timecode(
+            hours=0, minutes=0, seconds=0, frames=0,
+            frame_rate=StrictlyPositiveRational(24, 1),
+            dropFrame=False,
+        )
+        json_data = Timecode.to_json(tc)
+        self.assertNotIn("dropFrame", json_data,
+            "dropFrame=False (the default) should be excluded by exclude_defaults=True")
+
+    def test_drop_frame_true_included_in_timecode_json(self):
+        """Non-default dropFrame=True must appear in serialized JSON.
+
+        Non-vacuous complement: confirms the exclusion is selective — only the default
+        value is suppressed, not the field entirely.
+        """
+        tc = Timecode(
+            hours=0, minutes=0, seconds=0, frames=0,
+            frame_rate=StrictlyPositiveRational(30000, 1001),
+            dropFrame=True,
+        )
+        json_data = Timecode.to_json(tc)
+        self.assertIn("dropFrame", json_data,
+            "dropFrame=True (non-default) must be present in JSON")
+        self.assertTrue(json_data["dropFrame"])
+
+    @given(tc=timecodes())
+    @settings(suppress_health_check=_SUPPRESS)
+    def test_sub_frame_zero_always_excluded(self, tc):
+        """For any timecode, forcing sub_frame=0 causes subFrame to be absent from JSON.
+
+        Non-vacuous: generators produce varied sub_frame values; this test specifically
+        exercises the zero-value exclusion path.
+        """
+        tc_zero = Timecode(
+            hours=tc.hours, minutes=tc.minutes, seconds=tc.seconds,
+            frames=tc.frames, frame_rate=tc.frame_rate, sub_frame=0,
+        )
+        self.assertNotIn("subFrame", Timecode.to_json(tc_zero))
+
+    @given(tc=timecodes())
+    @settings(suppress_health_check=_SUPPRESS)
+    def test_nonzero_sub_frame_always_included(self, tc):
+        """For any timecode, setting sub_frame=1 causes subFrame to appear in JSON.
+
+        Non-vacuous complement: confirms exclude_defaults doesn't suppress the
+        entire field, only the zero default.
+        """
+        tc_nonzero = Timecode(
+            hours=tc.hours, minutes=tc.minutes, seconds=tc.seconds,
+            frames=tc.frames, frame_rate=tc.frame_rate, sub_frame=1,
+        )
+        json_data = Timecode.to_json(tc_nonzero)
+        self.assertIn("subFrame", json_data)
+        self.assertEqual(json_data["subFrame"], 1)
+
+
+# ---------------------------------------------------------------------------
+# None exclusion and optional-field neutrality
+# ---------------------------------------------------------------------------
+
+class OptionalFieldNeutralityTests(unittest.TestCase):
+
+    def test_unset_optional_and_explicit_none_produce_same_json(self):
+        """Setting clip.lens_nominal_focal_length = None explicitly is identical to
+        leaving it unset — both produce the same JSON document.
+
+        Non-vacuous: a model that tracked 'explicitly set to None' as a different
+        state from 'never set' would produce different output for these two clips.
+        """
+        clip_unset = Clip()
+
+        clip_explicit = Clip()
+        clip_explicit.lens_nominal_focal_length = None
+
+        self.assertEqual(Clip.to_json(clip_unset), Clip.to_json(clip_explicit))
+
+    def test_extra_json_fields_are_rejected(self):
+        """[gap] Camdkit rejects unrecognized JSON keys — extra='forbid' is in effect.
+
+        Non-vacuous: documents a forward-compatibility gap. A producer emitting
+        fields from a newer version of the OpenTrackIO spec will cause from_json
+        to raise a ValidationError in consumers built on the current camdkit.
+        Producers and consumers must be kept at the same spec version.
+        """
+        json_with_future_field = {
+            "static": {
+                "lens": {
+                    "nominalFocalLength": 35.0,
+                    "fieldFromFutureSpecVersion": "causes ValidationError",
+                }
+            }
+        }
+        with self.assertRaises(Exception,
+                msg="from_json must raise when it encounters an unrecognized field"):
+            Clip.from_json(json_with_future_field)
+
+    @given(clip=clips())
+    @settings(max_examples=75, suppress_health_check=_SUPPRESS)
+    def test_clip_json_contains_no_none_values(self, clip):
+        """to_json output must never contain None at any nesting level.
+
+        Non-vacuous: exclude_none=True must apply recursively through all nested
+        models. A regression that applied it only at the top level would allow None
+        values to appear inside nested objects such as SynchronizationPTP.
+        """
+        json_data = Clip.to_json(clip)
+        self.assertFalse(
+            _has_none(json_data),
+            "to_json must not emit None at any depth — exclude_none=True must be recursive"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic field length gap
+# ---------------------------------------------------------------------------
+
+class DynamicFieldLengthTests(unittest.TestCase):
+
+    def test_mismatched_dynamic_field_lengths_are_accepted(self):
+        """[gap] A clip with different per-sample field lengths is accepted without error.
+
+        The OpenTrackIO spec implies all dynamic fields in a given clip share the
+        same sample count. Clip enforces no such constraint: fields are stored as
+        independent tuples, so a producer can create a structurally inconsistent
+        clip that serializes and deserializes without any error or normalization.
+        """
+        clip = Clip()
+        clip.timing_mode = (TimingMode.INTERNAL,)     # 1 sample
+        clip.timing_sequence_number = (0, 1, 2)       # 3 samples
+
+        # Accepted at construction
+        self.assertEqual(len(clip.timing_mode), 1)
+        self.assertEqual(len(clip.timing_sequence_number), 3)
+
+        # Survives roundtrip unchanged — no validation, no normalization
+        recovered = Clip.from_json(Clip.to_json(clip))
+        self.assertEqual(len(recovered.timing_mode), 1)
+        self.assertEqual(len(recovered.timing_sequence_number), 3)
+
+    def test_single_frame_clip_is_consistent(self):
+        """A clip with a uniform single-sample field count is always consistent."""
+        clip = Clip()
+        clip.timing_mode = (TimingMode.EXTERNAL,)
+        clip.timing_sequence_number = (42,)
+        clip.timing_sample_rate = (StrictlyPositiveRational(24, 1),)
+
+        recovered = Clip.from_json(Clip.to_json(clip))
+        field_lengths = {
+            "timing_mode": len(recovered.timing_mode),
+            "timing_sequence_number": len(recovered.timing_sequence_number),
+            "timing_sample_rate": len(recovered.timing_sample_rate),
+        }
+        self.assertEqual(len(set(field_lengths.values())), 1,
+            f"All field lengths should be 1, got: {field_lengths}")
+
+
+# ---------------------------------------------------------------------------
+# Rational non-normalization
+# ---------------------------------------------------------------------------
+
+class RationalEquivalenceTests(unittest.TestCase):
+    """Camdkit compares rationals structurally, not semantically.
+
+    Rational(2, 4) and Rational(1, 2) represent the same mathematical value
+    but are treated as distinct by camdkit. Consumers that compare frame rates
+    or other rational quantities must normalize before comparing.
+    """
+
+    def test_equivalent_rationals_are_structurally_distinct(self):
+        """Rational(2, 4) != Rational(1, 2) — structural, not semantic, equality.
+
+        Non-vacuous: documents a consumer-side responsibility. A consumer that
+        checks `clip1.timing_sample_rate == clip2.timing_sample_rate` can get
+        False even when both represent the same rate.
+        """
+        r_unreduced = Rational(2, 4)
+        r_reduced = Rational(1, 2)
+        self.assertNotEqual(r_unreduced, r_reduced,
+            "Camdkit does not reduce fractions — Rational(2, 4) != Rational(1, 2)")
+
+    def test_equivalent_rationals_produce_different_json(self):
+        """Rational(2, 4) and Rational(1, 2) serialize to different JSON objects.
+
+        Non-vacuous: a serializer that reduced fractions would emit the same JSON
+        for both, hiding the structural distinction from consumers.
+        """
+        j_unreduced = Rational.to_json(Rational(2, 4))
+        j_reduced = Rational.to_json(Rational(1, 2))
+        self.assertNotEqual(j_unreduced, j_reduced,
+            "Semantically equivalent rationals must produce different JSON")
+        self.assertEqual(j_unreduced["num"], 2)
+        self.assertEqual(j_unreduced["denom"], 4)
+        self.assertEqual(j_reduced["num"], 1)
+        self.assertEqual(j_reduced["denom"], 2)
+
+    @given(r=rationals())
+    def test_roundtrip_preserves_exact_numerator_and_denominator(self, r):
+        """Roundtrip preserves the exact num and denom without reduction.
+
+        Non-vacuous companion to test_equivalent_rationals_are_structurally_distinct:
+        confirms that the structural identity is preserved through serialization, not
+        just in memory. A serializer that silently reduced fractions would pass the
+        Python equality check but change num/denom for unreduced inputs.
+        """
+        recovered = Rational.from_json(Rational.to_json(r))
+        self.assertEqual(recovered.num, r.num,
+            f"Numerator changed during roundtrip: {r.num} → {recovered.num}")
+        self.assertEqual(recovered.denom, r.denom,
+            f"Denominator changed during roundtrip: {r.denom} → {recovered.denom}")
+
+    def test_strictly_positive_rational_also_not_normalized(self):
+        """StrictlyPositiveRational is also structurally compared — fractions not reduced."""
+        r1 = StrictlyPositiveRational(4, 8)
+        r2 = StrictlyPositiveRational(1, 2)
+        self.assertNotEqual(r1, r2,
+            "StrictlyPositiveRational(4, 8) != StrictlyPositiveRational(1, 2)")
+
+    def test_frame_rate_structural_comparison_in_clip(self):
+        """Two clips with the same frame rate expressed differently are not equal.
+
+        Non-vacuous: documents that clip equality depends on exact rational
+        representation. A producer using 30/1 and a producer using 60/2 for the
+        same physical frame rate will produce clips that compare unequal.
+        """
+        clip_a = Clip()
+        clip_a.capture_frame_rate = StrictlyPositiveRational(30, 1)
+
+        clip_b = Clip()
+        clip_b.capture_frame_rate = StrictlyPositiveRational(60, 2)
+
+        self.assertNotEqual(clip_a, clip_b,
+            "Clips with 30/1 and 60/2 capture frame rates must compare unequal")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/python/property/test_schema_agreement.py
+++ b/src/test/python/property/test_schema_agreement.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the SMTPE RIS OSVP Metadata Project
+
+"""Property tests: generated Clip JSON validates against the published schema."""
+
+import json
+import unittest
+
+import jsonschema
+from hypothesis import given, settings, HealthCheck
+
+from camdkit.clip import Clip
+from camdkit.examples import _unwrap_clip_to_pseudo_frame
+
+from property.generators import clips
+
+_SUPPRESS = [HealthCheck.too_slow, HealthCheck.filter_too_much]
+
+CLIP_SCHEMA = None
+CLIP_VALIDATOR = None
+
+
+def setUpModule():
+    global CLIP_SCHEMA, CLIP_VALIDATOR
+    CLIP_SCHEMA = Clip.make_json_schema()
+    CLIP_VALIDATOR = jsonschema.Draft202012Validator(CLIP_SCHEMA)
+
+
+def _to_single_frame_json(clip):
+    """Return a schema-valid single-frame JSON dict for the clip.
+
+    Clip.to_json() produces multi-frame arrays for dynamic fields; the schema
+    expects single values. _unwrap_clip_to_pseudo_frame mirrors what the example
+    generators do before writing the example JSON files.
+    """
+    return json.loads(json.dumps(_unwrap_clip_to_pseudo_frame(clip.to_json(0))))
+
+
+class SchemaAgreementTests(unittest.TestCase):
+
+    @given(clip=clips())
+    @settings(max_examples=75, suppress_health_check=_SUPPRESS)
+    def test_valid_clip_validates_against_schema(self, clip):
+        """Every generated Clip's first frame passes schema validation."""
+        json_data = _to_single_frame_json(clip)
+        errors = list(CLIP_VALIDATOR.iter_errors(json_data))
+        if errors:
+            self.fail(
+                f"Schema validation failed for generated clip.\n"
+                f"First error: {errors[0].message}\n"
+                f"Path: {list(errors[0].path)}\n"
+                f"JSON: {json.dumps(json_data, indent=2)}"
+            )
+
+    def test_empty_clip_validates_against_schema(self):
+        """An empty Clip serializes to {} and the schema must accept it (all fields optional)."""
+        json_data = _to_single_frame_json(Clip())
+        self.assertEqual(json_data, {}, "Empty Clip should serialize to an empty document")
+        CLIP_VALIDATOR.validate(json_data)
+
+    def test_schema_is_stable(self):
+        """make_json_schema() is idempotent — calling it twice returns equal results."""
+        schema1 = Clip.make_json_schema()
+        schema2 = Clip.make_json_schema()
+        self.assertEqual(schema1, schema2)
+
+    def test_schema_rejects_wrong_rational_type(self):
+        """A rational with a string numerator must fail schema validation."""
+        bad = {"static": {"duration": {"num": "not-a-number", "denom": 1}}}
+        errors = list(CLIP_VALIDATOR.iter_errors(bad))
+        self.assertTrue(len(errors) > 0, "Schema should reject a non-integer rational numerator")
+
+    def test_schema_rejects_negative_denom(self):
+        """A rational with negative denominator must fail schema validation."""
+        bad = {"static": {"duration": {"num": 1, "denom": -1}}}
+        errors = list(CLIP_VALIDATOR.iter_errors(bad))
+        self.assertTrue(len(errors) > 0, "Schema should reject a negative denominator")
+
+    def test_schema_rejects_unknown_sync_source(self):
+        """An unrecognized synchronization source must fail schema validation."""
+        # Single-frame format: synchronization is a scalar object, not an array.
+        # Using an array would fail for the wrong reason (type mismatch, not enum).
+        bad = {
+            "timing": {
+                "synchronization": {
+                    "locked": True,
+                    "source": "bluetooth",
+                }
+            }
+        }
+        errors = list(CLIP_VALIDATOR.iter_errors(bad))
+        self.assertTrue(len(errors) > 0, "Schema should reject unknown synchronization source")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/python/property/test_stream_invariants.py
+++ b/src/test/python/property/test_stream_invariants.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the SMTPE RIS OSVP Metadata Project
+
+"""Stream invariant tests: temporal coherence and lens math correctness.
+
+These tests verify two categories of invariants:
+
+  Tier 1 — Temporal coherence: properties that must hold for a data stream to be
+    self-consistent (timestamps, sequence numbers, PTP coherence). Several tests
+    in this section document *gaps* — constraints the spec mandates but camdkit
+    does not enforce — so that consumers know they must validate themselves.
+
+  Tier 2 — Lens math: properties of the distortion model. The Brown-Conrady
+    self-consistency test is the core: it exercises the actual formula, not just
+    serialization.
+
+Tests labelled "[gap]" in their docstrings verify that camdkit accepts inputs
+that violate a semantic invariant. These are intentionally expected to pass —
+they document the gap.
+"""
+
+import math
+import unittest
+
+import jsonschema
+from hypothesis import given, settings, HealthCheck, assume
+from hypothesis import strategies as st
+from fractions import Fraction
+
+from camdkit.numeric_types import StrictlyPositiveRational
+from camdkit.timing_types import (
+    Timestamp, Timecode, Synchronization, SynchronizationSource,
+    SynchronizationPTP, SynchronizationPTPPriorities, PTPProfile,
+)
+from camdkit.lens_types import Distortion
+from camdkit.clip import Clip
+
+from property.generators import (
+    synchronization_ptps, synchronization_ptp_priorities,
+    strictly_positive_rationals,
+)
+
+_SUPPRESS = [HealthCheck.too_slow, HealthCheck.filter_too_much]
+
+CLIP_SCHEMA = None
+CLIP_VALIDATOR = None
+
+
+def setUpModule():
+    global CLIP_SCHEMA, CLIP_VALIDATOR
+    CLIP_SCHEMA = Clip.make_json_schema()
+    CLIP_VALIDATOR = jsonschema.Draft202012Validator(CLIP_SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# Brown-Conrady math — used by Tier 2 tests
+# ---------------------------------------------------------------------------
+
+def _brown_conrady_apply(x: float, y: float,
+                          radial: tuple, tangential: tuple | None = None
+                          ) -> tuple[float, float]:
+    """Apply the Brown-Conrady radial+tangential formula.
+
+    Both D-U and U-D models use the same polynomial; the caller decides what
+    (x, y) represents (distorted or undistorted input).
+
+        r² = x² + y²
+        κ(r) = (1 + k1·r² + k2·r⁴ + k3·r⁶) / (1 + k4·r² + k5·r⁴ + k6·r⁶)
+        x_out = x·κ + 2·p1·x·y + p2·(r² + 2·x²)
+        y_out = y·κ + p1·(r² + 2·y²) + 2·p2·x·y
+    """
+    r2 = x * x + y * y
+    r4 = r2 * r2
+    r6 = r4 * r2
+
+    k = list(radial) + [0.0] * (6 - len(radial))
+    k1, k2, k3, k4, k5, k6 = k[:6]
+
+    denom = 1.0 + k4 * r2 + k5 * r4 + k6 * r6
+    if abs(denom) < 1e-15:
+        return x, y  # degenerate denominator — skip
+    kappa = (1.0 + k1 * r2 + k2 * r4 + k3 * r6) / denom
+
+    xo = x * kappa
+    yo = y * kappa
+
+    if tangential:
+        p = list(tangential) + [0.0, 0.0]
+        p1, p2 = p[0], p[1]
+        xo += 2.0 * p1 * x * y + p2 * (r2 + 2.0 * x * x)
+        yo += p1 * (r2 + 2.0 * y * y) + 2.0 * p2 * x * y
+
+    return xo, yo
+
+
+def _brown_conrady_iterative_inverse(xd: float, yd: float,
+                                      radial: tuple, tangential: tuple | None = None,
+                                      max_iter: int = 200, tol: float = 1e-10
+                                      ) -> tuple[float, float]:
+    """Iteratively find (xu, yu) such that _brown_conrady_apply(xu, yu) ≈ (xd, yd).
+
+    Convergence rate per iteration is |f'(y) - 1| ≈ 3·|k1|·r². For |k1| ≤ 0.3
+    and r ≤ sqrt(2), the rate is at most 0.85, so 200 iterations gives residual
+    < 0.85^200 ≈ 3e-15 — well below the 1e-6 test tolerance.
+    """
+    xu, yu = xd, yd
+    for _ in range(max_iter):
+        xe, ye = _brown_conrady_apply(xu, yu, radial, tangential)
+        dx, dy = xd - xe, yd - ye
+        xu += dx
+        yu += dy
+        if dx * dx + dy * dy < tol * tol:
+            break
+    return xu, yu
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: Temporal coherence
+# ---------------------------------------------------------------------------
+
+class TimingCoherenceTests(unittest.TestCase):
+
+    # --- PTP coherence gap ---
+
+    def test_ptp_source_without_ptp_object_is_accepted(self):
+        """[gap] Camdkit accepts source=PTP with no ptp object.
+
+        The spec requires a ptp block when source is 'ptp', but Synchronization
+        has no model validator enforcing this. A producer that sets source=PTP
+        and omits the ptp block will not be caught by camdkit — consumers must
+        validate this themselves.
+        """
+        sync = Synchronization(locked=True, source=SynchronizationSource.PTP)
+        self.assertIsNone(sync.ptp)
+        # It also round-trips without error, silently preserving the invalid state.
+        clip = Clip()
+        clip.timing_synchronization = (sync,)
+        recovered = Clip.from_json(Clip.to_json(clip))
+        self.assertIsNone(recovered.timing_synchronization[0].ptp)
+
+    def test_schema_does_not_enforce_ptp_coherence(self):
+        """[gap] The JSON schema accepts source=PTP without a ptp block.
+
+        JSON Schema (Draft 2020-12) cannot easily express the cross-field
+        constraint 'if source == ptp then ptp is required'. The schema therefore
+        accepts this invalid combination, leaving validation to the consumer.
+        """
+        bad = {
+            "timing": {
+                "synchronization": {
+                    "locked": True,
+                    "source": "ptp",
+                    # no "ptp" block
+                }
+            }
+        }
+        errors = list(CLIP_VALIDATOR.iter_errors(bad))
+        self.assertEqual(errors, [],
+            "Schema should have no objection to missing ptp block — this documents the gap")
+
+    @given(ptp=synchronization_ptps())
+    @settings(suppress_health_check=_SUPPRESS)
+    def test_ptp_object_survives_roundtrip_when_source_is_ptp(self, ptp):
+        """When source=PTP and a ptp block is present, the block is not dropped on roundtrip.
+
+        Non-vacuous: an incorrect serializer could drop the optional ptp field
+        while preserving the source enum value, silently destroying the data.
+        """
+        sync = Synchronization(
+            locked=True,
+            source=SynchronizationSource.PTP,
+            ptp=ptp,
+        )
+        clip = Clip()
+        clip.timing_synchronization = (sync,)
+        recovered = Clip.from_json(Clip.to_json(clip))
+        r_sync = recovered.timing_synchronization[0]
+        self.assertEqual(r_sync.source, SynchronizationSource.PTP)
+        self.assertIsNotNone(r_sync.ptp,
+            "ptp block must not be dropped during roundtrip when source=PTP")
+        self.assertEqual(r_sync.ptp, ptp)
+
+    # --- Timestamp nanoseconds gap ---
+
+    def test_timestamp_nanoseconds_above_999_million_is_accepted(self):
+        """[gap] Timestamp.nanoseconds accepts values > 999_999_999.
+
+        The field is named 'nanoseconds' implying SI values of 0–999_999_999,
+        but the type is NonNegativeInt (uint32, up to 4_294_967_295). Values
+        that would imply more than one second of nanoseconds are silently accepted
+        and round-trip without error — there is no normalisation.
+        """
+        overflow_ns = 1_500_000_000  # 1.5 billion: more than one second
+        ts = Timestamp(seconds=0, nanoseconds=overflow_ns)
+        recovered = Timestamp.from_json(Timestamp.to_json(ts))
+        self.assertEqual(recovered.nanoseconds, overflow_ns,
+            "Nanosecond overflow value is preserved, not rejected or normalised")
+
+    # --- Timecode frame boundary ---
+
+    def test_timecode_frame_at_max_valid_is_accepted(self):
+        """frames = ceil(frame_rate) - 1 is the maximum valid frame and must be accepted."""
+        # For 24 fps: valid range is 0-23
+        tc = Timecode(
+            hours=0, minutes=0, seconds=0, frames=23,
+            frame_rate=StrictlyPositiveRational(24, 1),
+        )
+        recovered = Timecode.from_json(Timecode.to_json(tc))
+        self.assertEqual(recovered.frames, 23)
+
+    def test_timecode_frame_at_ceiling_is_rejected(self):
+        """frames = ceil(frame_rate) must be rejected — it is one frame past the end."""
+        with self.assertRaises(Exception):
+            Timecode(
+                hours=0, minutes=0, seconds=0, frames=24,
+                frame_rate=StrictlyPositiveRational(24, 1),
+            )
+
+    def test_timecode_frame_boundary_for_drop_frame_rate(self):
+        """frames = ceil(30000/1001) - 1 = 29 is valid for a drop-frame-rate clip."""
+        # ceil(30000/1001) = ceil(29.97...) = 30, so max frame = 29
+        tc = Timecode(
+            hours=0, minutes=0, seconds=0, frames=29,
+            frame_rate=StrictlyPositiveRational(30000, 1001),
+            dropFrame=True,
+        )
+        recovered = Timecode.from_json(Timecode.to_json(tc))
+        self.assertEqual(recovered.frames, 29)
+
+    def test_timecode_frame_ceiling_for_drop_frame_rate_is_rejected(self):
+        """frames = 30 must be rejected for a 30000/1001 clip (ceil = 30)."""
+        with self.assertRaises(Exception):
+            Timecode(
+                hours=0, minutes=0, seconds=0, frames=30,
+                frame_rate=StrictlyPositiveRational(30000, 1001),
+                dropFrame=True,
+            )
+
+    @given(frame_rate=strictly_positive_rationals())
+    @settings(suppress_health_check=_SUPPRESS)
+    def test_timecode_frame_boundary_holds_for_any_rate(self, frame_rate):
+        """For any frame rate, frames at max valid survives roundtrip;
+        frames one over is rejected at construction.
+
+        Non-vacuous: the validator computes ceil(num/denom) dynamically, so a
+        broken validator could accept or reject wrong values for unusual rates.
+        """
+        ceil_rate = math.ceil(Fraction(frame_rate.num, frame_rate.denom))
+        max_frames = min(ceil_rate - 1, 119)
+        assume(max_frames >= 0)
+
+        tc = Timecode(
+            hours=0, minutes=0, seconds=0, frames=max_frames,
+            frame_rate=frame_rate,
+        )
+        recovered = Timecode.from_json(Timecode.to_json(tc))
+        self.assertEqual(recovered.frames, max_frames)
+
+        if max_frames < 119:  # can we go one over without hitting the Field cap?
+            with self.assertRaises(Exception):
+                Timecode(
+                    hours=0, minutes=0, seconds=0, frames=max_frames + 1,
+                    frame_rate=frame_rate,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: Lens math
+# ---------------------------------------------------------------------------
+
+# Hypothesis strategies for well-conditioned distortion parameters.
+#
+# Convergence of the simple iteration requires that the spectral radius of
+# (I - J_f) < 1, where J_f is the Jacobian of the distortion function.
+# For radial-only Brown-Conrady, the dominant eigenvalue is 1 + 3·k1·r².
+# Convergence requires |3·k1·r²| + |5·k2·r⁴| < 1.
+#
+# With |k1| ≤ 0.2, |k2| ≤ 0.05, and points in [-0.7, 0.7] (r² ≤ 0.98):
+#   3·0.2·0.98 + 5·0.05·0.96 = 0.588 + 0.240 = 0.828 < 1  ✓
+# Adding small tangential (|p| ≤ 0.005) contributes < 0.03, still < 1.
+# With 200 iterations: 0.86^200 ≈ 2e-14 — well below 1e-6 test tolerance.
+_small_k1 = st.floats(min_value=-0.2, max_value=0.2, allow_nan=False, allow_infinity=False)
+_small_tangential_p = st.floats(min_value=-0.005, max_value=0.005, allow_nan=False, allow_infinity=False)
+_convergence_domain = st.floats(min_value=-0.7, max_value=0.7, allow_nan=False, allow_infinity=False)
+
+
+@st.composite
+def well_conditioned_ud_distortions(draw):
+    """U-D Distortion with coefficients that guarantee iterative inverse convergence.
+
+    Bounds derived from convergence analysis: 3·|k1|·r_max² + 5·|k2|·r_max⁴ < 1
+    at r_max = sqrt(2) * 0.7 ≈ 0.99.
+    """
+    k1 = draw(_small_k1)
+    k2 = draw(st.floats(min_value=-0.05, max_value=0.05, allow_nan=False, allow_infinity=False))
+    radial = (k1, k2)
+
+    if draw(st.booleans()):
+        p1 = draw(_small_tangential_p)
+        p2 = draw(_small_tangential_p)
+        tangential = (p1, p2)
+    else:
+        tangential = None
+
+    return Distortion(model="Brown-Conrady U-D", radial=radial, tangential=tangential)
+
+
+class LensMathTests(unittest.TestCase):
+
+    # --- Schema overscan constraint ---
+
+    def test_schema_rejects_static_distortion_overscan_below_unity(self):
+        """The schema must reject distortionOverscanMax < 1.0.
+
+        Non-vacuous: this exercises the schema's 'minimum: 1.0' constraint on the
+        static lens overscan field. A schema that omitted the minimum would pass
+        the 'above unity' test but fail this one.
+        """
+        bad = {"static": {"lens": {"distortionOverscanMax": 0.9}}}
+        errors = list(CLIP_VALIDATOR.iter_errors(bad))
+        self.assertGreater(len(errors), 0,
+            "Schema should reject distortionOverscanMax < 1.0")
+
+    def test_schema_accepts_static_distortion_overscan_at_unity(self):
+        """The schema must accept distortionOverscanMax = 1.0 exactly.
+
+        Non-vacuous: a schema using 'exclusiveMinimum: 1.0' would incorrectly
+        reject the boundary value.
+        """
+        ok = {"static": {"lens": {"distortionOverscanMax": 1.0}}}
+        errors = list(CLIP_VALIDATOR.iter_errors(ok))
+        self.assertEqual(errors, [],
+            "Schema should accept distortionOverscanMax = 1.0 (boundary must be valid)")
+
+    def test_schema_rejects_undistortion_overscan_below_unity(self):
+        """The schema must reject undistortionOverscanMax < 1.0."""
+        bad = {"static": {"lens": {"undistortionOverscanMax": 0.5}}}
+        errors = list(CLIP_VALIDATOR.iter_errors(bad))
+        self.assertGreater(len(errors), 0,
+            "Schema should reject undistortionOverscanMax < 1.0")
+
+    def test_schema_accepts_undistortion_overscan_at_unity(self):
+        """The schema must accept undistortionOverscanMax = 1.0 exactly."""
+        ok = {"static": {"lens": {"undistortionOverscanMax": 1.0}}}
+        errors = list(CLIP_VALIDATOR.iter_errors(ok))
+        self.assertEqual(errors, [],
+            "Schema should accept undistortionOverscanMax = 1.0")
+
+    # --- Distortion model name constraint ---
+
+    def test_schema_accepts_arbitrary_distortion_model_name(self):
+        """[gap] The schema places no constraint on distortion model names beyond non-blank.
+
+        A consumer receives 'model' as a plain string and must validate it against
+        its own supported set. Camdkit does not enumerate valid model names in the
+        schema — any non-blank string is accepted.
+        """
+        ok = {
+            "lens": {
+                "distortion": [
+                    {"model": "some-future-lens-model-2025", "radial": [0.1]}
+                ]
+            }
+        }
+        errors = list(CLIP_VALIDATOR.iter_errors(ok))
+        self.assertEqual(errors, [],
+            "Schema accepts any non-blank model name — model validation is consumer-side")
+
+    def test_schema_rejects_blank_distortion_model_name(self):
+        """The schema must reject an empty string as a model name."""
+        bad = {
+            "lens": {
+                "distortion": [
+                    {"model": "", "radial": [0.1]}
+                ]
+            }
+        }
+        errors = list(CLIP_VALIDATOR.iter_errors(bad))
+        self.assertGreater(len(errors), 0,
+            "Schema should reject empty string as distortion model name")
+
+    # --- Brown-Conrady self-consistency ---
+
+    @given(
+        dist=well_conditioned_ud_distortions(),
+        xu=_convergence_domain,
+        yu=_convergence_domain,
+    )
+    @settings(max_examples=300, suppress_health_check=_SUPPRESS)
+    def test_brown_conrady_ud_self_consistency(self, dist, xu, yu):
+        """Brown-Conrady U-D: iterative_undistort(distort(p)) ≈ p within 1e-6.
+
+        Non-vacuous: this exercises the actual distortion formula and its iterative
+        inverse. It would fail if the formula was wrong, the coefficients ill-conditioned,
+        or the iteration failed to converge. The coefficient and domain bounds are
+        chosen so convergence is guaranteed by analysis (see comment above the strategy).
+        """
+        radial = dist.radial
+        tangential = dist.tangential
+
+        xd, yd = _brown_conrady_apply(xu, yu, radial, tangential)
+        assume(math.isfinite(xd) and math.isfinite(yd))
+
+        xu_rec, yu_rec = _brown_conrady_iterative_inverse(xd, yd, radial, tangential)
+
+        self.assertAlmostEqual(xu_rec, xu, places=6,
+            msg=f"x recovery failed: radial={radial}, tangential={tangential}, "
+                f"input=({xu:.6f},{yu:.6f}), distorted=({xd:.6f},{yd:.6f})")
+        self.assertAlmostEqual(yu_rec, yu, places=6,
+            msg=f"y recovery failed: radial={radial}, tangential={tangential}, "
+                f"input=({xu:.6f},{yu:.6f}), distorted=({xd:.6f},{yd:.6f})")
+
+    @given(
+        dist=well_conditioned_ud_distortions(),
+        xu=_convergence_domain,
+        yu=_convergence_domain,
+    )
+    @settings(max_examples=150, suppress_health_check=_SUPPRESS)
+    def test_brown_conrady_ud_coefficients_survive_serialization(self, dist, xu, yu):
+        """Distortion coefficients produce the same output before and after JSON roundtrip.
+
+        Non-vacuous: if float precision was lost during serialization (e.g., truncated
+        to fewer decimal places), the distortion output would differ.
+        """
+        xd_before, yd_before = _brown_conrady_apply(xu, yu, dist.radial, dist.tangential)
+        assume(math.isfinite(xd_before) and math.isfinite(yd_before))
+
+        recovered = Distortion.from_json(Distortion.to_json(dist))
+        xd_after, yd_after = _brown_conrady_apply(
+            xu, yu, recovered.radial, recovered.tangential
+        )
+
+        self.assertAlmostEqual(xd_before, xd_after, places=10,
+            msg="Distortion x output changed after coefficient serialization roundtrip")
+        self.assertAlmostEqual(yd_before, yd_after, places=10,
+            msg="Distortion y output changed after coefficient serialization roundtrip")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/python/property/test_stream_invariants.py
+++ b/src/test/python/property/test_stream_invariants.py
@@ -199,6 +199,42 @@ class TimingCoherenceTests(unittest.TestCase):
         self.assertEqual(recovered.nanoseconds, overflow_ns,
             "Nanosecond overflow value is preserved, not rejected or normalised")
 
+    # --- PTP domain boundary ---
+
+    def test_ptp_domain_boundary_127_accepted_128_rejected(self):
+        """SynchronizationPTP.domain is correctly bounded to [0..127].
+
+        The model uses NonNegative8BitInt (MAX_INT_8 = 127), matching the spec's
+        PTP domain range for SMPTE ST2059-2 and IEEE 1588 profiles. Domain=127
+        is the valid maximum; domain=128 is rejected by the validator.
+
+        Non-vacuous: an earlier LLD draft claimed this was a gap (the full byte
+        range [0..255] was accepted). Verified against the actual model — the
+        constraint IS enforced.
+        """
+        # 127 is the valid maximum and must be accepted
+        ptp = SynchronizationPTP(
+            profile=PTPProfile.SMPTE_2059_2_2021,
+            domain=127,
+            leader_identity="00:11:22:33:44:55",
+            leader_priorities=SynchronizationPTPPriorities(1, 2),
+            leader_accuracy=0.0,
+            mean_path_delay=0.0,
+        )
+        recovered = SynchronizationPTP.from_json(SynchronizationPTP.to_json(ptp))
+        self.assertEqual(recovered.domain, 127)
+
+        # 128 is one past the valid maximum and must be rejected
+        with self.assertRaises(Exception):
+            SynchronizationPTP(
+                profile=PTPProfile.SMPTE_2059_2_2021,
+                domain=128,
+                leader_identity="00:11:22:33:44:55",
+                leader_priorities=SynchronizationPTPPriorities(1, 2),
+                leader_accuracy=0.0,
+                mean_path_delay=0.0,
+            )
+
     # --- Timecode frame boundary ---
 
     def test_timecode_frame_at_max_valid_is_accepted(self):

--- a/src/test/python/test_mosys_reader.py
+++ b/src/test/python/test_mosys_reader.py
@@ -15,6 +15,7 @@ from camdkit.framework import (Vector3, Rotator3,
                                FizEncoders, Distortion, ProjectionOffset)
 from camdkit.model import OPENTRACKIO_PROTOCOL_NAME, OPENTRACKIO_PROTOCOL_VERSION
 from camdkit.mosys import reader
+from camdkit.mosys.f4 import F4PacketParser
 
 class MoSysReaderTest(unittest.TestCase):
   
@@ -43,3 +44,29 @@ class MoSysReaderTest(unittest.TestCase):
     self.assertEqual(clip.lens_projection_offset[13], ProjectionOffset(-7.783590793609619, 6.896144866943359))
     self.assertAlmostEqual(clip.lens_pinhole_focal_length[14], 22.35, 2)
     self.assertEqual(int(clip.lens_focus_distance[15]*1000), 2313)
+
+
+class MoSysF4ParserUnitTest(unittest.TestCase):
+
+  # Minimal valid F4 packet: focal length (45°) + focus encoder — no timecode axis.
+  # Without a timecode axis, frequency stays None and Synchronization(frequency=None)
+  # raises a validation error. Checksum = (0x40 - sum(header+body)) % 256 = 0xfd.
+  _PACKET_NO_TIMECODE = bytes([
+    0xf4, 0x01, 0x02, 0x00,         # command, camera_id=1, axis_count=2, status=0
+    0x53, 0x42, 0x34, 0x00, 0x00,   # focal length FX axis: 45.0 degrees (IEEE 754)
+    0x03, 0x00, 0x00, 0x80, 0x00,   # focus encoder axis: 50%
+    0xfd,                             # checksum
+  ])
+
+  def test_no_timecode_axis_does_not_crash(self):
+    """get_tracking_frame() must not raise when no timecode axis is present.
+
+    frequency defaults to None. Without a guard, Synchronization(frequency=None)
+    raises a Pydantic validation error because frequency is StrictlyPositiveRational.
+    The parser must skip synchronization construction and leave
+    timing_synchronization unset.
+    """
+    parser = F4PacketParser()
+    self.assertTrue(parser.initialise(self._PACKET_NO_TIMECODE))
+    frame = parser.get_tracking_frame()
+    self.assertIsNone(frame.timing_synchronization)


### PR DESCRIPTION
## Summary

`get_tracking_frame()` in `mosys/f4.py` unconditionally constructs
`Synchronization(frequency=frequency)` at the end of every frame. `frequency`
defaults to `None` and is only set when a timecode axis (`0xF8`) appears in
the packet. `Synchronization.frequency` is typed as `StrictlyPositiveRational`,
which does not accept `None`, so the constructor raises a Pydantic validation
error and crashes the parser.

## Demonstration

BEFORE: `F4PacketParser.get_tracking_frame()` on any packet with no timecode
  axis raises a Pydantic `ValidationError` on `Synchronization(frequency=None)`

AFTER:
  returns a valid frame with `timing_synchronization` unset (`None`)

## Impact

Any F4 packet that omits the timecode axis (`FIELD_ID_TIMECODE`, `0xF8`)
causes `get_tracking_frame()` to raise, aborting frame parsing. Callers
receive an unhandled exception rather than a partial frame.

## Change

`mosys/f4.py`: wrap the `Synchronization` construction and
`frame.timing_synchronization` assignment in a `if frequency is not None`
guard so they are only executed when a timecode axis was present in the
packet. Four-line change.

`test_mosys_reader.py`: add `test_no_timecode_axis_does_not_crash` — a unit
test using a hand-crafted minimal packet with no timecode axis. Verifies the
parser returns a valid frame with `timing_synchronization` unset.

## Found via

Hypothesis-based property testing against a synthetic F4 packet generator.
Packets containing only the minimum required axes triggered the crash
immediately on the first generated example.
